### PR TITLE
Update non_linear_multi_fidelity_model.py

### DIFF
--- a/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
+++ b/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
@@ -325,7 +325,8 @@ class NonLinearMultiFidelityModel(IModel, IDifferentiable):
         # Optimize all models for all fidelities but lowest fidelity
         for i in range(1, self.n_fidelities):
             # Set new X values because previous model has changed
-            previous_mean, _ = self.models[i - 1].predict(self.models[i].X)
+            is_ith_fidelity = self.X[:, self._fidelity_idx] == i
+            previous_mean, _ = self._predict_deterministic(self.X[is_ith_fidelity, :-1], i)
             augmented_input = np.concatenate([self.models[i].X[:, :-1], previous_mean], axis=1)
             self.models[i].set_X(augmented_input)
 


### PR DESCRIPTION
*Issue #321*

*Description of changes:*
Update prediction for previous fidelity during call to optimize (lines 328-329). Previous implementation only made a call to the predict method of the previous fidelity model. It did not properly propagate information from lowest level model to the current fidelity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
