### PR TITLE
Bandit parameters compatibility with check in domain bugfix

### DIFF
--- a/emukit/core/bandit_parameter.py
+++ b/emukit/core/bandit_parameter.py
@@ -69,6 +69,11 @@ class BanditParameter(Parameter):
             parameters.append(parameter)
         return parameters
 
+
+    @property
+    def model_parameters(self) -> List:
+        return self.parameters
+
     def check_in_domain(self, x: Union[np.ndarray, float, list]) -> Union[bool, np.ndarray]:
         """
         Checks if all the points in x lie in the domain set

--- a/emukit/core/optimization/context_manager.py
+++ b/emukit/core/optimization/context_manager.py
@@ -20,6 +20,7 @@ class ContextManager:
         :param context: Dictionary of variables and their context values.
                         These values are fixed while optimization.
         """
+        self.context = context
         self.space = space
         self.contextfree_space = ParameterSpace(
             [param for param in self.space.parameters if param.name not in context])
@@ -36,7 +37,7 @@ class ContextManager:
             # Find encoded values of context variable
             param = self.space.get_parameter_by_name(name)
             if hasattr(param, 'encoding'):
-                self.context_values.append(param.encoding.get_encoding(context[name]))
+                self.context_values.extend(param.encoding.get_encoding(context[name]))
             else:
                 self.context_values.append(context[name])
 

--- a/tests/emukit/core/optimization/test_context_manager.py
+++ b/tests/emukit/core/optimization/test_context_manager.py
@@ -43,9 +43,6 @@ def catg_context():
 def test_context_manager_catg_expand_vector(catg_space, catg_context):
     context_manager = ContextManager(catg_space, catg_context)
     x = np.array([[4., -1], [3, 0.]])
-    print(context_manager.non_context_idxs)
-    print(context_manager.context_idxs)
-
     x_expanded = context_manager.expand_vector(x)
     assert context_manager.space.dimensionality == 11
     assert x_expanded.shape == (2, context_manager.space.dimensionality)

--- a/tests/emukit/core/optimization/test_context_manager.py
+++ b/tests/emukit/core/optimization/test_context_manager.py
@@ -1,14 +1,13 @@
 import numpy as np
 import pytest
 
-from emukit.core import ContinuousParameter, ParameterSpace
+from emukit.core import ContinuousParameter, CategoricalParameter, ParameterSpace
+from emukit.core import OneHotEncoding
 from emukit.core.optimization import ContextManager
-
 
 @pytest.fixture
 def space():
     return ParameterSpace([ContinuousParameter('x1', 0, 15), ContinuousParameter('x2', 0, 15)])
-
 
 @pytest.fixture
 def context():
@@ -28,3 +27,27 @@ def test_context_manager_expand_vector(space, context):
     x_expanded = context_manager.expand_vector(x)
     assert x_expanded.ndim == 2
     assert np.array_equal(x_expanded, np.array([[0.3, 0.5]]))
+
+
+@pytest.fixture
+def catg_space():
+    return ParameterSpace([ContinuousParameter('x1', 0, 15), 
+                           CategoricalParameter('x2', OneHotEncoding([0, 1, 2, 3])),
+                           CategoricalParameter('x3', OneHotEncoding([1, 2, 3, 4, 5])),
+                           ContinuousParameter('x4', -2, 3)]) 
+
+@pytest.fixture
+def catg_context():
+    return {'x2': 0, 'x3': 3}
+
+def test_context_manager_catg_expand_vector(catg_space, catg_context):
+    context_manager = ContextManager(catg_space, catg_context)
+    x = np.array([[4., -1], [3, 0.]])
+    print(context_manager.non_context_idxs)
+    print(context_manager.context_idxs)
+
+    x_expanded = context_manager.expand_vector(x)
+    assert context_manager.space.dimensionality == 11
+    assert x_expanded.shape == (2, context_manager.space.dimensionality)
+    assert np.array_equal(x_expanded, np.array([[4., 1, 0, 0, 0, 0, 0, 1, 0, 0, -1.],[3, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0.]]))
+    


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The ParameterSpace check_points_in_domain is currently not compatible with bandit parameters because the call to "len(param.model_parameters)" on L127 of the parameter_space.py source will return 1 for a bandit parameter.
By adding the property model_parameters() to the bandit implementation following the same logic of categorical parameters, we ensure the compatibility of check_points_in_domain with bandit parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.