### PR TITLE
Fixed bug in examples/fabolas/fmin.py.

### DIFF
--- a/emukit/examples/fabolas/fmin.py
+++ b/emukit/examples/fabolas/fmin.py
@@ -47,7 +47,7 @@ def fmin_fabolas(func, space: ParameterSpace, s_min: float, s_max: float, n_iter
         cost_init[it] = cost
 
     def wrapper(x):
-        y, c = func(x[0, :-1], np.exp(x[0, -1]))
+        y, c = func(x[0, :-1], x[0, -1])
 
         return np.array([[y]]), np.array([[c]])
 


### PR DESCRIPTION
It seems that there was an artifact in the implementation of the fabolas optimizer in the given examples from a previous implementation of log-scale sampling of the dataset fraction. This is a small fix that removes the said artifact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
