### PR TITLE
Fix notebooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 /.mypy_cache/
 /.vscode/
+/.venv/
 
 __pycache__/
 *.py[cod]

--- a/requirements/integration_test_requirements.txt
+++ b/requirements/integration_test_requirements.txt
@@ -6,4 +6,4 @@ pybnn==0.0.5
 PyDOE>=0.3.0
 # For notebook tests
 jupyter==1.0.0
-pandas==0.25.*
+pandas>=1.0.5

--- a/requirements/integration_test_requirements.txt
+++ b/requirements/integration_test_requirements.txt
@@ -6,4 +6,4 @@ pybnn==0.0.5
 PyDOE>=0.3.0
 # For notebook tests
 jupyter==1.0.0
-pandas==0.24.2
+pandas==0.25.*


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Recently all builds started failing. Error was in sensitivity notebook, and looked like this:
>TypeError: Cannot interpret '<attribute 'dtype' of 'numpy.generic' objects>'

as a data type on that line

```
pd.DataFrame(d).plot(kind='bar',figsize=(12, 5))
```

This turned out to be incompatibility issue between numpy 1.20.0 and pandas 0.24.*. This shall hopefully fix it. Maybe we shall also get rid of pandas in this notebook, it's the only one using it?

Reference: https://github.com/numpy/numpy/issues/18355


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
