### PR TITLE
Fixes GPyModelWrapper.generate_hyperparameters_samples changes the value of fixed parameters

### DIFF
--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -136,7 +136,8 @@ class GPyModelWrapper(IModel, IDifferentiable, IJointlyDifferentiable, ICalculat
         self.model.optimize(max_iters=self.n_restarts)
         unfixed_params = [param for param in self.model.flattened_parameters if not param.is_fixed]
         for param in unfixed_params:
-            param *= (1. + np.random.randn(param.size)) * 0.01
+            # Add jitter by multiplying with log-normal noise with mean 1 and standard deviation 0.01 
+            param *= np.random.lognormal(np.log(1. / np.sqrt(1.0001)), np.sqrt(np.log(1.0001)))
         hmc = GPy.inference.mcmc.HMC(self.model, stepsize=step_size)
         samples = hmc.sample(num_samples=n_burnin + n_samples * subsample_interval, hmc_iters=leapfrog_steps)
         hmc_samples = samples[n_burnin::subsample_interval]

--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -136,7 +136,7 @@ class GPyModelWrapper(IModel, IDifferentiable, IJointlyDifferentiable, ICalculat
         self.model.optimize(max_iters=self.n_restarts)
         unfixed_params = [param for param in self.model.flattened_parameters if not param.is_fixed]
         for param in unfixed_params:
-            param *= (1. + np.random.randn(param.size))
+            param *= (1. + np.random.randn(param.size)) * 0.01
         hmc = GPy.inference.mcmc.HMC(self.model, stepsize=step_size)
         samples = hmc.sample(num_samples=n_burnin + n_samples * subsample_interval, hmc_iters=leapfrog_steps)
         hmc_samples = samples[n_burnin::subsample_interval]

--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -134,7 +134,9 @@ class GPyModelWrapper(IModel, IDifferentiable, IJointlyDifferentiable, ICalculat
 
         """
         self.model.optimize(max_iters=self.n_restarts)
-        self.model.param_array[:] = self.model.param_array * (1. + np.random.randn(self.model.param_array.size) * 0.01)
+        unfixed_params = [param for param in self.model.flattened_parameters if not param.is_fixed]
+        for param in unfixed_params:
+            param *= (1. + np.random.randn(param.size))
         hmc = GPy.inference.mcmc.HMC(self.model, stepsize=step_size)
         samples = hmc.sample(num_samples=n_burnin + n_samples * subsample_interval, hmc_iters=leapfrog_steps)
         hmc_samples = samples[n_burnin::subsample_interval]

--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -137,7 +137,7 @@ class GPyModelWrapper(IModel, IDifferentiable, IJointlyDifferentiable, ICalculat
         unfixed_params = [param for param in self.model.flattened_parameters if not param.is_fixed]
         for param in unfixed_params:
             # Add jitter by multiplying with log-normal noise with mean 1 and standard deviation 0.01 
-            param *= np.random.lognormal(np.log(1. / np.sqrt(1.0001)), np.sqrt(np.log(1.0001)))
+            param *= np.random.lognormal(np.log(1. / np.sqrt(1.0001)), np.sqrt(np.log(1.0001)), size=param.size)
         hmc = GPy.inference.mcmc.HMC(self.model, stepsize=step_size)
         samples = hmc.sample(num_samples=n_burnin + n_samples * subsample_interval, hmc_iters=leapfrog_steps)
         hmc_samples = samples[n_burnin::subsample_interval]


### PR DESCRIPTION
*Issue #, if available:* #344

*Description of changes:*

Fixes the referenced hyperparameter sampling issue by only adding random noise to the unfixed parameters before initiating HMC sampling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
