### PR TITLE
Update doc-string for get_covariance_between_points()

### DIFF
--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -108,11 +108,13 @@ class GPyModelWrapper(
     def get_covariance_between_points(self, X1: np.ndarray, X2: np.ndarray) -> np.ndarray:
         """
         Calculate posterior covariance between two points
-        :param X1: An array of shape 1 x n_dimensions that contains a data single point. It is the first argument of the
+        :param X1: An array of shape n_points1 x n_dimensions. It is the first argument of the
                    posterior covariance function
-        :param X2: An array of shape n_points x n_dimensions that may contain multiple data points. This is the second
+        :param X2: An array of shape n_points2 x n_dimensions. This is the second
                    argument to the posterior covariance function.
-        :return: An array of shape n_points x 1 of posterior covariances between X1 and X2
+        :return: An array of shape n_points1 x n_points2 of posterior covariances between X1 and X2.
+            Namely, [i, j]-th entry of the returned array will represent the posterior covariance
+            between i-th point in X1 and j-th point in X2.
         """
         return self.model.posterior_covariance_between_points(X1, X2, include_likelihood=False)
 


### PR DESCRIPTION
*Issue:* #367 

The mentioned method `GPyModelWrapper.get_covariance_between_points()` is in fact more general than the doc-string implies. Updated the doc-string accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
