### PR TITLE
added square-root warping and factored out warpings in BQ

### DIFF
--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -19,7 +19,7 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
 
     def __init__(self, base_gp: IBaseGaussianProcess, X: np.ndarray, Y: np.ndarray):
         """
-        :param base_gp: A model derived from :class:`emukit.quadrature.interfaces.IBaseGaussianProcess`
+        :param base_gp: The underlying Gaussian process model.
         :param X: The initial locations of integrand evaluations, shape (num_points, input_dim).
         :param Y: The values of the integrand at X, shape (num_points, 1).
         """

--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -20,17 +20,17 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
     def __init__(self, base_gp: IBaseGaussianProcess, X: np.ndarray, Y: np.ndarray):
         """
         :param base_gp: The underlying Gaussian process model.
-        :param X: The initial locations of integrand evaluations, shape (num_points, input_dim).
-        :param Y: The values of the integrand at X, shape (num_points, 1).
+        :param X: The initial locations of integrand evaluations, shape (n_points, input_dim).
+        :param Y: The values of the integrand at X, shape (n_points, 1).
         """
         super(VanillaBayesianQuadrature, self).__init__(base_gp=base_gp, warping=IdentityWarping(), X=X, Y=Y)
 
     def predict_base(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Compute predictive means and variances of the warped GP as well as the base GP.
 
-        :param X_pred: Locations at which to predict, shape (num_points, input_dim).
-        :returns: Predictive mean and variances of warped GP, and predictive mean and variances of base-GP in that order
-                  all shapes (num_points, 1).
+        :param X_pred: Locations at which to predict, shape (n_points, input_dim).
+        :returns: Predictive mean and variances of warped GP, and predictive mean and variances of base-GP in that
+                  order all shapes (n_points, 1).
         """
         m, cov = self.base_gp.predict(X_pred)
         return m, cov, m, cov
@@ -39,9 +39,9 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
                                                                              np.ndarray]:
         """Compute predictive means and covariance of the warped GP as well as the base GP.
 
-        :param X_pred: Locations at which to predict, shape (num_points, input_dim)
+        :param X_pred: Locations at which to predict, shape (n_points, input_dim).
         :returns: Predictive mean and covariance of warped GP, predictive mean and covariance of base-GP in that order.
-                  mean shapes both (num_points, 1) and covariance shapes both (num_points, num_points)
+                  mean shapes both (n_points, 1) and covariance shapes both (n_points, n_points).
         """
         m, cov = self.base_gp.predict_with_full_covariance(X_pred)
         return m, cov, m, cov
@@ -59,8 +59,8 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
     def get_prediction_gradients(self, X: np.ndarray) -> Tuple:
         """Compute predictive gradients of mean and variance at given points.
 
-        :param X: Points to compute gradients at, shape (num_points, input_dim).
-        :returns: Tuple of gradients of mean and variance, shapes of both (num_points, input_dim).
+        :param X: Points to compute gradients at, shape (n_points, input_dim).
+        :returns: Tuple of gradients of mean and variance, shapes of both (n_points, input_dim).
         """
         # gradient of mean
         d_mean_dx = (self.base_gp.kern.dK_dx1(X, self.X) @ self.base_gp.graminv_residual())[:, :, 0].T
@@ -76,7 +76,7 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
     def update_parameters(self, X: np.ndarray, Y: np.ndarray) -> None:
         """Update parameters of the model that are not being optimized. Use pass if no parameters need to be updated.
 
-        :param X: Observation locations, shape (num_points, input_dim)
-        :param Y: Integrand observations at X, shape (num_points, 1)
+        :param X: Observation locations, shape (n_points, input_dim).
+        :param Y: Integrand observations at X, shape (n_points, 1).
         """
         pass

--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -72,11 +72,3 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
         d_var_dx = dKdiag_dx - 2. * (dKxX_dx1 * np.transpose(graminv_KXx)).sum(axis=2, keepdims=False)
 
         return d_mean_dx, d_var_dx.T
-
-    def update_parameters(self, X: np.ndarray, Y: np.ndarray) -> None:
-        """Update parameters of the model that are not being optimized. Use pass if no parameters need to be updated.
-
-        :param X: Observation locations, shape (n_points, input_dim).
-        :param Y: Integrand observations at X, shape (n_points, 1).
-        """
-        pass

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -28,8 +28,8 @@ class WarpedBayesianQuadratureModel(IModel):
         """
         :param base_gp: The underlying Gaussian process model.
         :param warping: The warping of the underlying Gaussian process model.
-        :param X: The initial locations of integrand evaluations, shape (num_points, input_dim).
-        :param Y: The values of the integrand at X, shape (num_points, 1).
+        :param X: The initial locations of integrand evaluations, shape (n_points, input_dim).
+        :param Y: The values of the integrand at X, shape (n_points, 1).
         """
         self._warping = warping
         self.base_gp = base_gp
@@ -70,9 +70,9 @@ class WarpedBayesianQuadratureModel(IModel):
     def predict_base(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Compute predictive means and variances of the warped GP as well as the base GP.
 
-        :param X_pred: Locations at which to predict, shape (num_points, input_dim).
+        :param X_pred: Locations at which to predict, shape (n_points, input_dim).
         :returns: Predictive mean and variances of warped GP, and predictive mean and variances of base-GP in that order
-                  all shapes (num_points, 1).
+                  all shapes (n_points, 1).
         """
         raise NotImplemented
 
@@ -80,9 +80,9 @@ class WarpedBayesianQuadratureModel(IModel):
                                                                              np.ndarray]:
         """Compute predictive means and covariance of the warped GP as well as the base GP.
 
-        :param X_pred: Locations at which to predict, shape (num_points, input_dim)
+        :param X_pred: Locations at which to predict, shape (n_points, input_dim)
         :returns: Predictive mean and covariance of warped GP, predictive mean and covariance of base-GP in that order.
-                  mean shapes both (num_points, 1) and covariance shapes both (num_points, num_points)
+                  mean shapes both (n_points, 1) and covariance shapes both (n_points, n_points)
         """
         raise NotImplemented
 
@@ -108,8 +108,8 @@ class WarpedBayesianQuadratureModel(IModel):
         First, the model parameters that are not being optimized are updated, as they may depend on the new data,
         then new data is set in the model.
 
-        :param X: Observation locations, shape (num_points, input_dim)
-        :param Y: Integrand observations at X, shape (num_points, 1)
+        :param X: Observation locations, shape (n_points, input_dim)
+        :param Y: Integrand observations at X, shape (n_points, 1)
         """
         self.update_parameters(X, Y)
         self.base_gp.set_data(X, self._warping.inverse_transform(Y))
@@ -117,8 +117,8 @@ class WarpedBayesianQuadratureModel(IModel):
     def update_parameters(self, X: np.ndarray, Y: np.ndarray) -> None:
         """Update parameters of the model that are not being optimized. Use pass if no parameters need to be updated.
 
-        :param X: Observation locations, shape (num_points, input_dim)
-        :param Y: Integrand observations at X, shape (num_points, 1)
+        :param X: Observation locations, shape (n_points, input_dim)
+        :param Y: Integrand observations at X, shape (n_points, 1)
         """
         raise NotImplementedError
 

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -115,12 +115,13 @@ class WarpedBayesianQuadratureModel(IModel):
         self.base_gp.set_data(X, self._warping.inverse_transform(Y))
 
     def update_parameters(self, X: np.ndarray, Y: np.ndarray) -> None:
-        """Update parameters of the model that are not being optimized. Use pass if no parameters need to be updated.
+        """Update parameters of the model that are not being optimized. Override this method on case parameters
+        are data dependent.
 
         :param X: Observation locations, shape (n_points, input_dim)
         :param Y: Integrand observations at X, shape (n_points, 1)
         """
-        raise NotImplementedError
+        pass
 
     def optimize(self) -> None:
         """Optimizes the hyperparameters of the base GP"""

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -13,8 +13,7 @@ from .warpings import Warping
 
 
 class WarpedBayesianQuadratureModel(IModel):
-    """
-    The general class for Bayesian quadrature (BQ) with a warped Gaussian process.
+    """The general class for Bayesian quadrature (BQ) with a warped Gaussian process.
 
     Inference is performed with the warped GP, but the integral is computed on a Gaussian approximation.
     The warping of the base GP is encoded in the methods 'transform' and 'inverse_transform'
@@ -27,14 +26,14 @@ class WarpedBayesianQuadratureModel(IModel):
     """
     def __init__(self, base_gp: IBaseGaussianProcess, warping: Warping, X: np.ndarray, Y: np.ndarray):
         """
-        :param base_gp: the underlying GP model
-        :param warping: The warping.
-        :param X: the initial locations of integrand evaluations
-        :param Y: the values of the integrand at Y
+        :param base_gp: The underlying Gaussian process model.
+        :param warping: The warping of the underlying Gaussian process model.
+        :param X: The initial locations of integrand evaluations, shape (num_points, input_dim).
+        :param Y: The values of the integrand at X, shape (num_points, 1).
         """
         self._warping = warping
         self.base_gp = base_gp
-        # this is to ensure that the base_gp get the correct transform
+        # set data to ensure that the base_gp get the correctly transformed observations.
         self.set_data(X, Y)
 
     @property
@@ -47,16 +46,17 @@ class WarpedBayesianQuadratureModel(IModel):
 
     @property
     def integral_bounds(self) -> Union[None, BoxBounds]:
+        """The integration bounds. ``None`` if integration domain is not bounded."""
         return self.base_gp.kern.integral_bounds
 
     @property
     def reasonable_box_bounds(self) -> BoxBounds:
+        """Reasonable box bounds to search for observations. This box is used by the acquisition optimizer."""
         return self.base_gp.kern.reasonable_box_bounds
 
     @property
     def measure(self) -> Union[None, IntegrationMeasure]:
-        """probability measure used for integration. Returns None for standard Lebesgue measure (not a probability
-        measure) """
+        """Probability measure used for integration. ``None`` for standard Lebesgue measure."""
         return self.base_gp.kern.measure
 
     def transform(self, Y: np.ndarray) -> np.ndarray:
@@ -68,29 +68,26 @@ class WarpedBayesianQuadratureModel(IModel):
         return self._warping.inverse_transform(Y)
 
     def predict_base(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """
-        Computes predictive means and variances of the warped GP as well as the base GP
+        """Compute predictive means and variances of the warped GP as well as the base GP.
 
-        :param X_pred: Locations at which to predict
-        :returns: predictive mean and variances of warped GP, and predictive mean and variances of base-GP in that order
-        all shapes (n_points, 1).
+        :param X_pred: Locations at which to predict, shape (num_points, input_dim).
+        :returns: Predictive mean and variances of warped GP, and predictive mean and variances of base-GP in that order
+                  all shapes (num_points, 1).
         """
         raise NotImplemented
 
     def predict_base_with_full_covariance(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray,
                                                                              np.ndarray]:
-        """
-        Computes predictive means and covariance of the warped GP as well as the base GP
+        """Compute predictive means and covariance of the warped GP as well as the base GP.
 
-        :param X_pred: Locations at which to predict, shape (n_points, input_dim)
-        :returns: predictive mean and covariance of warped GP, predictive mean and covariance of base-GP in that order.
-        mean shapes both (n_points, 1) and covariance shapes both (n_points, n_points)
+        :param X_pred: Locations at which to predict, shape (num_points, input_dim)
+        :returns: Predictive mean and covariance of warped GP, predictive mean and covariance of base-GP in that order.
+                  mean shapes both (num_points, 1) and covariance shapes both (num_points, num_points)
         """
         raise NotImplemented
 
     def predict_with_full_covariance(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-        """
-        Computes approximate predictive means and full co-variances of warped GP.
+        """Compute predictive means and covariance of warped GP.
 
         :param X_pred: Locations at which to predict, shape (n_points, input_dim)
         :return: predictive mean, predictive full covariance of warped-GP, shapes (n_points, 1) and (n_points, n_points)
@@ -98,8 +95,7 @@ class WarpedBayesianQuadratureModel(IModel):
         return self.predict_base_with_full_covariance(X_pred)[:2]
 
     def predict(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
-        """
-        Computes predictive means and variances of warped-GP.
+        """Compute predictive means and variances of warped-GP.
 
         :param X_pred: Locations at which to predict, shape (n_points, input_dim)
         :return: predictive mean, predictive variances of warped-GP, both shapes (n_points, 1)
@@ -107,20 +103,22 @@ class WarpedBayesianQuadratureModel(IModel):
         return self.predict_base(X_pred)[:2]
 
     def set_data(self, X: np.ndarray, Y: np.ndarray) -> None:
-        """
-        This method transforms the integrand y values and sets the data
-        :param X: observed locations
-        :param Y: observed integrand values
+        """Set the new data in the model.
+
+        First, the model parameters that are not being optimized are updated, as they may depend on the new data,
+        then new data is set in the model.
+
+        :param X: Observation locations, shape (num_points, input_dim)
+        :param Y: Integrand observations at X, shape (num_points, 1)
         """
         self.update_parameters(X, Y)
         self.base_gp.set_data(X, self._warping.inverse_transform(Y))
 
     def update_parameters(self, X: np.ndarray, Y: np.ndarray) -> None:
-        """
-        Update parameters of the model that are not being optimized. Use pass if no parameters need to be updated.
+        """Update parameters of the model that are not being optimized. Use pass if no parameters need to be updated.
 
-        :param X: observation locations, shape (num_points, dim)
-        :param Y: values of observations, shape (num_points, 1)
+        :param X: Observation locations, shape (num_points, input_dim)
+        :param Y: Integrand observations at X, shape (num_points, 1)
         """
         raise NotImplementedError
 
@@ -129,8 +127,8 @@ class WarpedBayesianQuadratureModel(IModel):
         self.base_gp.optimize()
 
     def integrate(self) -> Tuple[float, float]:
-        """
-        Computes an estimator of the integral as well as its variance.
-        :returns: estimator of integral and its variance
+        """Compute an estimator of the integral as well as its variance.
+
+        :returns: Estimator of integral and its variance.
         """
         raise NotImplemented

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -8,22 +8,22 @@ class Warping:
     def transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from base-GP to integrand.
 
-        :param Y: function values of latent function, shape (num_points, 1).
-        :return: transformed values, shape (num_points, 1)
+        :param Y: Function values of latent function, shape (n_points, 1).
+        :return: Transformed values, shape (n_points, 1).
         """
         raise NotImplemented
 
     def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from integrand to base-GP.
 
-        :param Y: function values of integrand, shape (num_points, 1).
-        :return: transformed values, shape (num_points, 1)
+        :param Y: Function values of integrand, shape (n_points, 1).
+        :return: Transformed values, shape (n_points, 1).
         """
         raise NotImplemented
 
-    def update_parameters(self, **kargs) -> None:
-        """Update the warping parameters. Use `pass` if there are no parameters."""
-        raise NotImplementedError
+    def update_parameters(self, **kwargs) -> None:
+        """Update the warping parameters."""
+        pass
 
 
 class IdentityWarping(Warping):
@@ -31,40 +31,36 @@ class IdentityWarping(Warping):
     def transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from base-GP to integrand.
 
-        :param Y: function values of latent function, shape (num_points, 1).
-        :return: transformed values, shape (num_points, 1)
+        :param Y: Function values of latent function, shape (n_points, 1).
+        :return: Transformed values, shape (n_points, 1).
         """
         return Y
 
     def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from integrand to base-GP.
 
-        :param Y: function values of integrand, shape (num_points, 1).
-        :return: transformed values, shape (num_points, 1)
+        :param Y: Function values of integrand, shape (n_points, 1).
+        :return: Transformed values, shape (n_points, 1).
         """
         return Y
-
-    def update_parameters(self) -> None:
-        """No update for the identity transform."""
-        pass
 
 
 class SquareRootWarping(Warping):
     """The square root warping"""
 
-    def __init__(self, offset: float, inverted: Optional[bool]=False):
+    def __init__(self, offset: float, is_inverted: Optional[bool]=False):
         """
-        :param offset: the offset of the warping
-        :param inverted: inverts the warping if ``True``. Default is ``False``.
+        :param offset: The offset of the warping.
+        :param is_inverted: Inverts the warping if ``True``. Default is ``False``.
         """
         self.offset = offset
-        self.inverted = inverted
+        self.inverted = is_inverted
 
     def transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from base-GP to integrand.
 
-        :param Y: function values of latent function, shape (num_points, 1).
-        :return: transformed values, shape (num_points, 1)
+        :param Y: Function values of latent function, shape (n_points, 1).
+        :return: Transformed values, shape (n_points, 1).
         """
         if self.inverted:
             return self.offset - 0.5 * (Y * Y)
@@ -74,8 +70,8 @@ class SquareRootWarping(Warping):
     def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from integrand to base-GP.
 
-        :param Y: function values of integrand, shape (num_points, 1).
-        :return: transformed values, shape (num_points, 1)
+        :param Y: Function values of integrand, shape (n_points, 1).
+        :return: Transformed values, shape (n_points, 1).
         """
         if self.inverted:
             return np.sqrt(2. * (self.offset - Y))
@@ -85,7 +81,7 @@ class SquareRootWarping(Warping):
     def update_parameters(self, offset: Optional[float]=None) -> None:
         """Update the :attr:`self.offset` if parameter is given.
 
-        :param offset: the new value of :attr:`self.offset`
+        :param offset: The new value of :attr:`self.offset`.
         """
         if offset is not None:
             self.offset = offset

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -54,7 +54,7 @@ class SquareRootWarping(Warping):
         :param is_inverted: Inverts the warping if ``True``. Default is ``False``.
         """
         self.offset = offset
-        self.inverted = is_inverted
+        self.is_inverted = is_inverted
 
     def transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from base-GP to integrand.
@@ -62,7 +62,7 @@ class SquareRootWarping(Warping):
         :param Y: Function values of latent function, shape (n_points, 1).
         :return: Transformed values, shape (n_points, 1).
         """
-        if self.inverted:
+        if self.is_inverted:
             return self.offset - 0.5 * (Y * Y)
         else:
             return self.offset + 0.5 * (Y * Y)
@@ -73,7 +73,7 @@ class SquareRootWarping(Warping):
         :param Y: Function values of integrand, shape (n_points, 1).
         :return: Transformed values, shape (n_points, 1).
         """
-        if self.inverted:
+        if self.is_inverted:
             return np.sqrt(2. * (self.offset - Y))
         else:
             return np.sqrt(2. * (Y - self.offset))

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -1,0 +1,91 @@
+import numpy as np
+from typing import Optional
+
+
+class Warping:
+    """The warping for warped Bayesian quadrature."""
+
+    def transform(self, Y: np.ndarray) -> np.ndarray:
+        """Transform from base-GP to integrand.
+
+        :param Y: function values of latent function, shape (num_points, 1).
+        :return: transformed values, shape (num_points, 1)
+        """
+        raise NotImplemented
+
+    def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
+        """Transform from integrand to base-GP.
+
+        :param Y: function values of integrand, shape (num_points, 1).
+        :return: transformed values, shape (num_points, 1)
+        """
+        raise NotImplemented
+
+    def update_parameters(self, **kargs) -> None:
+        """Update the warping parameters. Use `pass` if there are no parameters."""
+        raise NotImplementedError
+
+
+class IdentityWarping(Warping):
+
+    def transform(self, Y: np.ndarray) -> np.ndarray:
+        """Transform from base-GP to integrand.
+
+        :param Y: function values of latent function, shape (num_points, 1).
+        :return: transformed values, shape (num_points, 1)
+        """
+        return Y
+
+    def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
+        """Transform from integrand to base-GP.
+
+        :param Y: function values of integrand, shape (num_points, 1).
+        :return: transformed values, shape (num_points, 1)
+        """
+        return Y
+
+    def update_parameters(self) -> None:
+        """No update for the identity transform."""
+        pass
+
+
+class SquareRootWarping(Warping):
+    """The square root warping"""
+
+    def __init__(self, offset: float, inverted: Optional[bool]=False):
+        """
+        :param offset: the offset of the warping
+        :param inverted: inverts the warping if ``True``. Default is ``False``.
+        """
+        self.offset = offset
+        self.inverted = inverted
+
+    def transform(self, Y: np.ndarray) -> np.ndarray:
+        """Transform from base-GP to integrand.
+
+        :param Y: function values of latent function, shape (num_points, 1).
+        :return: transformed values, shape (num_points, 1)
+        """
+        if self.inverted:
+            return self.offset - 0.5 * (Y * Y)
+        else:
+            return self.offset + 0.5 * (Y * Y)
+
+    def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
+        """Transform from integrand to base-GP.
+
+        :param Y: function values of integrand, shape (num_points, 1).
+        :return: transformed values, shape (num_points, 1)
+        """
+        if self.inverted:
+            return np.sqrt(2. * (self.offset - Y))
+        else:
+            return np.sqrt(2. * (Y - self.offset))
+
+    def update_parameters(self, offset: Optional[float]=None) -> None:
+        """Update the :attr:`self.offset` if parameter is given.
+
+        :param offset: the new value of :attr:`self.offset`
+        """
+        if offset is not None:
+            self.offset = offset

--- a/notebooks/Emukit-tutorial-Bayesian-quadrature-introduction.ipynb
+++ b/notebooks/Emukit-tutorial-Bayesian-quadrature-introduction.ipynb
@@ -885,7 +885,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/Emukit-tutorial-experimental-design-introduction.ipynb
+++ b/notebooks/Emukit-tutorial-experimental-design-introduction.ipynb
@@ -609,7 +609,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,

--- a/tests/emukit/quadrature/test_warpings.py
+++ b/tests/emukit/quadrature/test_warpings.py
@@ -25,7 +25,7 @@ def squarerroot_warping():
 @pytest.fixture
 def inverted_squarerroot_warping():
     offset = 1.
-    return SquareRootWarping(offset=offset, inverted=True)
+    return SquareRootWarping(offset=offset, is_inverted=True)
 
 
 warpings_tuple = namedtuple('WarpingTest', ['name'])

--- a/tests/emukit/quadrature/test_warpings.py
+++ b/tests/emukit/quadrature/test_warpings.py
@@ -1,0 +1,64 @@
+import numpy as np
+from numpy.testing import assert_allclose
+from collections import namedtuple
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from emukit.quadrature.methods.warpings import IdentityWarping, SquareRootWarping
+
+
+def create_fixture_parameters():
+    return [pytest.param(lazy_fixture(warping.name), id=warping.name) for warping in warpings]
+
+
+@pytest.fixture
+def identity_warping():
+    return IdentityWarping()
+
+
+@pytest.fixture
+def squarerroot_warping():
+    offset = 1.
+    return SquareRootWarping(offset=offset)
+
+
+@pytest.fixture
+def inverted_squarerroot_warping():
+    offset = 1.
+    return SquareRootWarping(offset=offset, inverted=True)
+
+
+warpings_tuple = namedtuple('WarpingTest', ['name'])
+warpings = [warpings_tuple('identity_warping'),
+            warpings_tuple('squarerroot_warping'),
+            warpings_tuple('inverted_squarerroot_warping')
+            ]
+
+
+RTOL = 1e-8
+ATOL = 1e-6
+
+
+@pytest.mark.parametrize('warping', create_fixture_parameters())
+def test_warping_shapes(warping):
+    Y = np.ones([5, 1])
+    assert warping.transform(Y).shape == Y.shape
+    assert warping.inverse_transform(Y).shape == Y.shape
+
+
+@pytest.mark.parametrize('warping', create_fixture_parameters())
+def test_warping_values(warping):
+    np.random.seed(42)
+    Y = np.random.rand(5, 1)
+
+    assert_allclose(warping.inverse_transform(warping.transform(Y)), Y, rtol=RTOL, atol=ATOL)
+
+
+def test_squarerroot_warping_update_parameters(squarerroot_warping, inverted_squarerroot_warping):
+    new_offset = 10.
+
+    squarerroot_warping.update_parameters(offset=new_offset)
+    assert squarerroot_warping.offset == new_offset
+
+    inverted_squarerroot_warping.update_parameters(offset=new_offset)
+    assert inverted_squarerroot_warping.offset == new_offset

--- a/tests/emukit/quadrature/test_warpings.py
+++ b/tests/emukit/quadrature/test_warpings.py
@@ -62,3 +62,8 @@ def test_squarerroot_warping_update_parameters(squarerroot_warping, inverted_squ
 
     inverted_squarerroot_warping.update_parameters(offset=new_offset)
     assert inverted_squarerroot_warping.offset == new_offset
+
+
+def test_squarerroot_warping_inverted_flag(squarerroot_warping, inverted_squarerroot_warping):
+    assert not squarerroot_warping.is_inverted
+    assert inverted_squarerroot_warping.is_inverted


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- this is another pre-PR for #375 
- factored out the warping from warped Gaussian process. We had discussed that previously @apaleyes  but it hadn't made sense back then as there was only 1 warping and you cannot mix and match warpings with models. However, now we need another warping that will be used by at least 2 methods, and you anyways cannot mix and match in BQ, so here we go..
- some docstring unifications
- added and `update_parameters` method to the warping model (will need that later).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
