### PR TITLE
moving gradients of base GP to base GP class 

### DIFF
--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -6,12 +6,11 @@ import numpy as np
 from typing import Tuple
 
 from ...quadrature.interfaces.base_gp import IBaseGaussianProcess
-from ...core.interfaces.models import IDifferentiable
 from .warped_bq_model import WarpedBayesianQuadratureModel
 from .warpings import IdentityWarping
 
 
-class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
+class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel):
     """Vanilla Bayesian quadrature.
 
     Vanilla Bayesian quadrature uses a Gaussian process as surrogate for the integrand.
@@ -62,13 +61,4 @@ class VanillaBayesianQuadrature(WarpedBayesianQuadratureModel, IDifferentiable):
         :param X: Points to compute gradients at, shape (n_points, input_dim).
         :returns: Tuple of gradients of mean and variance, shapes of both (n_points, input_dim).
         """
-        # gradient of mean
-        d_mean_dx = (self.base_gp.kern.dK_dx1(X, self.X) @ self.base_gp.graminv_residual())[:, :, 0].T
-
-        # gradient of variance
-        dKdiag_dx = self.base_gp.kern.dKdiag_dx(X)
-        dKxX_dx1 = self.base_gp.kern.dK_dx1(X, self.X)
-        graminv_KXx = self.base_gp.solve_linear(self.base_gp.kern.K(self.base_gp.X, X))
-        d_var_dx = dKdiag_dx - 2. * (dKxX_dx1 * np.transpose(graminv_KXx)).sum(axis=2, keepdims=False)
-
-        return d_mean_dx, d_var_dx.T
+        return self.base_gp.get_prediction_gradients(X)

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -74,7 +74,7 @@ class WarpedBayesianQuadratureModel(IModel, IDifferentiable):
         :returns: Predictive mean and variances of warped GP, and predictive mean and variances of base-GP in that order
                   all shapes (n_points, 1).
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def predict_base_with_full_covariance(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray, np.ndarray,
                                                                              np.ndarray]:
@@ -84,7 +84,7 @@ class WarpedBayesianQuadratureModel(IModel, IDifferentiable):
         :returns: Predictive mean and covariance of warped GP, predictive mean and covariance of base-GP in that order.
                   mean shapes both (n_points, 1) and covariance shapes both (n_points, n_points)
         """
-        raise NotImplemented
+        raise NotImplementedError
 
     def predict_with_full_covariance(self, X_pred: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
         """Compute predictive means and covariance of warped GP.
@@ -133,4 +133,4 @@ class WarpedBayesianQuadratureModel(IModel, IDifferentiable):
 
         :returns: Estimator of integral and its variance.
         """
-        raise NotImplemented
+        raise NotImplementedError

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -134,12 +134,3 @@ class WarpedBayesianQuadratureModel(IModel, IDifferentiable):
         :returns: Estimator of integral and its variance.
         """
         raise NotImplemented
-
-    @staticmethod
-    def _symmetrize(A: np.ndarray) -> np.ndarray:
-        """Symmetrize a matrix.
-
-        :param A: A square matrix, shape (N, N)
-        :return: The symmetrized matrix 0.5 (A + A').
-        """
-        return 0.5 * (A + A.T)

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -5,14 +5,14 @@
 import numpy as np
 from typing import Tuple, Union
 
-from ...core.interfaces.models import IModel
+from ...core.interfaces.models import IModel, IDifferentiable
 from ...quadrature.interfaces.base_gp import IBaseGaussianProcess
 from ...quadrature.kernels.bounds import BoxBounds
 from ...quadrature.kernels.integration_measures import IntegrationMeasure
 from .warpings import Warping
 
 
-class WarpedBayesianQuadratureModel(IModel):
+class WarpedBayesianQuadratureModel(IModel, IDifferentiable):
     """The general class for Bayesian quadrature (BQ) with a warped Gaussian process.
 
     Inference is performed with the warped GP, but the integral is computed on a Gaussian approximation.
@@ -111,17 +111,18 @@ class WarpedBayesianQuadratureModel(IModel):
         :param X: Observation locations, shape (n_points, input_dim)
         :param Y: Integrand observations at X, shape (n_points, 1)
         """
-        self.update_parameters(X, Y)
+        self._warping.update_parameters(**self.compute_warping_params(X, Y))
         self.base_gp.set_data(X, self._warping.inverse_transform(Y))
 
-    def update_parameters(self, X: np.ndarray, Y: np.ndarray) -> None:
-        """Update parameters of the model that are not being optimized. Override this method on case parameters
-        are data dependent.
+    def compute_warping_params(self, X: np.ndarray, Y: np.ndarray) -> dict:
+        """Compute parameters of the warping that are dependent on data, and that are not being optimized.
+        Override this method on case parameters are data dependent.
 
         :param X: Observation locations, shape (n_points, input_dim)
         :param Y: Integrand observations at X, shape (n_points, 1)
+        :returns : Dictionary containing new warping parameters. Names of parameters are the keys.
         """
-        pass
+        return {}
 
     def optimize(self) -> None:
         """Optimizes the hyperparameters of the base GP"""
@@ -133,3 +134,12 @@ class WarpedBayesianQuadratureModel(IModel):
         :returns: Estimator of integral and its variance.
         """
         raise NotImplemented
+
+    @staticmethod
+    def _symmetrize(A: np.ndarray) -> np.ndarray:
+        """Symmetrize a matrix.
+
+        :param A: A square matrix, shape (N, N)
+        :return: The symmetrized matrix 0.5 (A + A').
+        """
+        return 0.5 * (A + A.T)

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -1,29 +1,33 @@
+import abc
 import numpy as np
 from typing import Optional
 
 
-class Warping:
+class Warping(abc.ABC):
     """The warping for warped Bayesian quadrature."""
 
+    @abc.abstractmethod
     def transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from base-GP to integrand.
 
         :param Y: Function values of latent function, shape (n_points, 1).
         :return: Transformed values, shape (n_points, 1).
         """
-        raise NotImplemented
+        pass
 
+    @abc.abstractmethod
     def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
         """Transform from integrand to base-GP.
 
         :param Y: Function values of integrand, shape (n_points, 1).
         :return: Transformed values, shape (n_points, 1).
         """
-        raise NotImplemented
-
-    def update_parameters(self, **kwargs) -> None:
-        """Update the warping parameters."""
         pass
+
+    def update_parameters(self, **new_parameters) -> None:
+        """Update the warping parameters. The keyword arguments ``new_parameters`` contain the parameter names as
+        keys with the new values. An empty dictionary will not update any parameters."""
+        self.__dict__.update(new_parameters)
 
 
 class IdentityWarping(Warping):
@@ -77,11 +81,3 @@ class SquareRootWarping(Warping):
             return np.sqrt(2. * (self.offset - Y))
         else:
             return np.sqrt(2. * (Y - self.offset))
-
-    def update_parameters(self, offset: Optional[float]=None) -> None:
-        """Update the :attr:`self.offset` if parameter is given.
-
-        :param offset: The new value of :attr:`self.offset`.
-        """
-        if offset is not None:
-            self.offset = offset

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -13,7 +13,7 @@ class Warping(abc.ABC):
         :param Y: Function values of latent function, shape (n_points, 1).
         :return: Transformed values, shape (n_points, 1).
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def inverse_transform(self, Y: np.ndarray) -> np.ndarray:
@@ -22,12 +22,13 @@ class Warping(abc.ABC):
         :param Y: Function values of integrand, shape (n_points, 1).
         :return: Transformed values, shape (n_points, 1).
         """
-        pass
+        raise NotImplementedError
 
     def update_parameters(self, **new_parameters) -> None:
         """Update the warping parameters. The keyword arguments ``new_parameters`` contain the parameter names as
         keys with the new values. An empty dictionary will not update any parameters."""
-        self.__dict__.update(new_parameters)
+        for parameter, new_value in new_parameters.items():
+            setattr(self, parameter, new_value)
 
 
 class IdentityWarping(Warping):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Gradients:
- this is another pre-PR to #375 
- moved the gradients of the base-GP from the VanillaBQ class to the base GP where they belong. This wasn't an issue so far as VanillaBQ is basically the BaseGP just with a different API. This is still neater though, and will come in handy later.

Warpings (warping classes were introduced in PR #379 ):
- converted the base class of the warping to an abstract class. 
- the new parameter for the warping are now passed via keyword arguments. It is a bit more readable like this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
