### PR TITLE
Validate categorical variables when used in contexts 

### DIFF
--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -24,20 +24,6 @@ class AcquisitionOptimizerBase(abc.ABC):
         """
         self.space = space
 
-    def _validate_context_parameters(self, context: Dict[str, any]):
-        for context_name, context_value in context.items():
-            # Check parameter exists in space
-            if context_name not in self.space.parameter_names:
-                raise ValueError(context_name + ' appears as variable in context but not in the parameter space.')
-
-            # Log warning if context parameter is out of domain
-            param = self.space.get_parameter_by_name(context_name)
-            in_domain = context_value in param.encoding.categories if hasattr(param, 'encoding') else param.check_in_domain(context_value)
-            if in_domain:
-                _log.info('Parameter ' + context_name + ' fixed to ' + str(context_value))
-            else:
-                _log.warning(context_name + ' with value ' + str(context_value), ' is out of the domain')
-
     @abc.abstractmethod
     def _optimize(self, acquisition: Acquisition, context_manager: ContextManager) -> Tuple[np.ndarray, np.ndarray]:
         """
@@ -60,8 +46,6 @@ class AcquisitionOptimizerBase(abc.ABC):
         """
         if context is None:
             context = dict()
-        else:
-            self._validate_context_parameters(context)
         context_manager = ContextManager(self.space, context)
         max_x, max_value = self._optimize(acquisition, context_manager)
 

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -32,10 +32,11 @@ class AcquisitionOptimizerBase(abc.ABC):
 
             # Log warning if context parameter is out of domain
             param = self.space.get_parameter_by_name(context_name)
-            if param.check_in_domain(context_value) is False:
-                _log.warning(context_name + ' with value ' + str(context_value), ' is out of the domain')
-            else:
+            in_domain = context_value in param.encoding.categories if hasattr(param, 'encoding') else param.check_in_domain(context_value)
+            if in_domain:
                 _log.info('Parameter ' + context_name + ' fixed to ' + str(context_value))
+            else:
+                _log.warning(context_name + ' with value ' + str(context_value), ' is out of the domain')
 
     @abc.abstractmethod
     def _optimize(self, acquisition: Acquisition, context_manager: ContextManager) -> Tuple[np.ndarray, np.ndarray]:

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -3,7 +3,7 @@
 
 import abc
 import logging
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 
@@ -23,20 +23,6 @@ class AcquisitionOptimizerBase(abc.ABC):
         :param space: Parameter space containing entire input domain including any context variables
         """
         self.space = space
-
-    def _validate_context_parameters(self, context: Dict[str, any]):
-        for context_name, context_value in context.items():
-            # Check parameter exists in space
-            if context_name not in self.space.parameter_names:
-                raise ValueError(context_name + ' appears as variable in context but not in the parameter space.')
-
-            # Log warning if context parameter is out of domain
-            param = self.space.get_parameter_by_name(context_name)
-            if not hasattr(param, 'encoding'):
-                if param.check_in_domain(context_value):
-                    _log.info(f'Parameter {context_name} fixed to {context_value}')
-                else:
-                    _log.warning(f'{context_name} with value {context_value} is out of the domain')
 
     @abc.abstractmethod
     def _optimize(self, acquisition: Acquisition, context_manager: ContextManager) -> Tuple[np.ndarray, np.ndarray]:
@@ -60,8 +46,6 @@ class AcquisitionOptimizerBase(abc.ABC):
         """
         if context is None:
             context = dict()
-        else:
-            self._validate_context_parameters(context)
         context_manager = ContextManager(self.space, context)
         max_x, max_value = self._optimize(acquisition, context_manager)
 

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -2,16 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import abc
-import logging
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 
 from .. import ParameterSpace
 from ..acquisition import Acquisition
 from .context_manager import Context, ContextManager
-
-_log = logging.getLogger(__name__)
 
 
 class AcquisitionOptimizerBase(abc.ABC):

--- a/emukit/core/optimization/context_manager.py
+++ b/emukit/core/optimization/context_manager.py
@@ -30,16 +30,18 @@ class ContextManager:
         # Find indices of context and non context variables
         self.context_idxs = []
         self.context_values = []
-        for name in context.keys():
+        for context_name, context_value in context.items():
             # Find indices of variable in the input domain
-            self.context_idxs += self.space.find_parameter_index_in_model(name)
+            self.context_idxs += self.space.find_parameter_index_in_model(context_name)
 
             # Find encoded values of context variable
-            param = self.space.get_parameter_by_name(name)
+            param = self.space.get_parameter_by_name(context_name)
             if hasattr(param, 'encoding'):
-                self.context_values.extend(param.encoding.get_encoding(context[name]))
+                if context_value not in param.encoding.categories:
+                    raise ValueError(f'Context value {context_value} not found in encoding for {context_name}')
+                self.context_values.extend(param.encoding.get_encoding(context_value))
             else:
-                self.context_values.append(context[name])
+                self.context_values.append(context_value)
 
         all_idxs = list(range(space.dimensionality))
         self.non_context_idxs = [idx for idx in all_idxs if idx not in self.context_idxs]

--- a/emukit/core/optimization/context_manager.py
+++ b/emukit/core/optimization/context_manager.py
@@ -3,9 +3,12 @@
 
 from typing import Any, Dict
 
+import logging
 import numpy as np
 
 from .. import ParameterSpace
+
+_log = logging.getLogger(__name__)
 
 Context = Dict[str, Any]
 
@@ -37,10 +40,16 @@ class ContextManager:
             # Find encoded values of context variable
             param = self.space.get_parameter_by_name(context_name)
             if hasattr(param, 'encoding'):
-                if context_value not in param.encoding.categories:
+                if context_value in param.encoding.categories:
+                    _log.info(f'Parameter {context_name} fixed to {context_value}')
+                    self.context_values.extend(param.encoding.get_encoding(context_value))
+                else:
                     raise ValueError(f'Context value {context_value} not found in encoding for {context_name}')
-                self.context_values.extend(param.encoding.get_encoding(context_value))
             else:
+                if param.check_in_domain(context_value):
+                    _log.info(f'Parameter {context_name} fixed to {context_value}')
+                else:
+                    _log.warning(f'{context_name} with value {context_value} is out of the domain')
                 self.context_values.append(context_value)
 
         all_idxs = list(range(space.dimensionality))

--- a/tests/emukit/core/optimization/test_context_manager.py
+++ b/tests/emukit/core/optimization/test_context_manager.py
@@ -32,13 +32,13 @@ def test_context_manager_expand_vector(space, context):
 @pytest.fixture
 def catg_space():
     return ParameterSpace([ContinuousParameter('x1', 0, 15), 
-                           CategoricalParameter('x2', OneHotEncoding([0, 1, 2, 3])),
+                           CategoricalParameter('x2', OneHotEncoding(['A', 'B', 'C', 'D'])),
                            CategoricalParameter('x3', OneHotEncoding([1, 2, 3, 4, 5])),
                            ContinuousParameter('x4', -2, 3)]) 
 
 @pytest.fixture
 def catg_context():
-    return {'x2': 0, 'x3': 3}
+    return {'x2': 'A', 'x3': 3}
 
 def test_context_manager_catg_expand_vector(catg_space, catg_context):
     context_manager = ContextManager(catg_space, catg_context)
@@ -48,3 +48,7 @@ def test_context_manager_catg_expand_vector(catg_space, catg_context):
     assert x_expanded.shape == (2, context_manager.space.dimensionality)
     assert np.array_equal(x_expanded, np.array([[4., 1, 0, 0, 0, 0, 0, 1, 0, 0, -1.],[3, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0.]]))
     
+def test_context_manager_incorrect_category(catg_space):
+    erroneous_context = {'x2': 0, 'x3': 3}
+    with pytest.raises(ValueError):
+        context_manager = ContextManager(catg_space, erroneous_context)

--- a/tests/emukit/core/optimization/test_gradient_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_gradient_acquisition_optimizer.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from emukit.core import ContinuousParameter
+from emukit.core import ContinuousParameter, CategoricalParameter, OneHotEncoding
 from emukit.core import ParameterSpace
 from emukit.core.optimization import GradientAcquisitionOptimizer
 
@@ -13,3 +13,14 @@ def test_gradient_acquisition_optimizer(simple_square_acquisition):
     opt_x, opt_val = optimizer.optimize(simple_square_acquisition)
     assert_array_equal(opt_x, np.array([[0.]]))
     assert_array_equal(opt_val, np.array([[1.]]))
+
+def test_gradient_acquisition_optimizer_categorical(simple_square_acquisition):
+    space = ParameterSpace([
+        ContinuousParameter('x', 0, 1),
+        CategoricalParameter('y', OneHotEncoding(['A', 'B']))
+    ])
+    optimizer = GradientAcquisitionOptimizer(space)
+    context = {'y': 'B'}
+    opt_x, opt_val = optimizer.optimize(simple_square_acquisition, context)
+    assert_array_equal(opt_x, np.array([[0., 0., 1.]]))
+    assert_array_equal(opt_val, np.array([[2.]]))


### PR DESCRIPTION
Problem addressed
---------------------
Previously, if an `AcquisitionOptimizer` received a categorical variable, it would incorrectly attempt to check whether the value was *in-domain*. It was assuming that the encoded value was being passed (of type `np.ndarray`). If passing a `str` category, this would fail, while passing a numerical category would lead to various (mostly wrong) outcomes, without warning.

Changes
---------
- It is now possible to use categorical variables in contexts. The `ContextManager` is now solely responsible for *in-domain* checks (for continuous parameters, raising warnings upon failure) and *in-encoding* checks (for categorical parameters, raising `ValueError` upon failure).
- Also changed `any` to `Any` in context type.

Related
--------
- Issue #359 could be related to this.
- PR #381 introduced an alternative set of changes to the same problem.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
