### PR TITLE
Fix issue with creating IntegratedHyperParameterAcquisition objects

### DIFF
--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -58,11 +58,8 @@ class LocalPenalizationPointCalculator(CandidatePointCalculator):
         self.acquisition.update_parameters()
 
         # Initialize local penalization acquisition
-        import logging
         if isinstance(self.model, IPriorHyperparameters):
-            logging.info("local_penalization_calculator.py:63: creating IntegratedHyperParameterAcquisition instance")
             local_penalization_acquisition = IntegratedHyperParameterAcquisition(self.model, LocalPenalization)
-            logging.info(f"local_penalization_calculator.py:65: created  IntegratedHyperParameterAcquisition instance {local_penalization_acquisition}")
         else:
             local_penalization_acquisition = LocalPenalization(self.model)
 
@@ -72,10 +69,9 @@ class LocalPenalizationPointCalculator(CandidatePointCalculator):
 
         x_batch = []
         y_batch = []
-        for i in range(self.batch_size):
+        for _ in range(self.batch_size):
             # Collect point
             x_next, y_next = self.acquisition_optimizer.optimize(acquisition, context)
-            logging.info(f"Iteration {i+1} of {self.batch_size}: x_next = {x_next}, y_next = {y_next}")
             x_batch.append(x_next)
             y_batch.append(y_next)
 

--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -89,17 +89,8 @@ class LocalPenalizationPointCalculator(CandidatePointCalculator):
                 lipschitz_constant = _estimate_lipschitz_constant(self.parameter_space, self.model)
             else:
                 lipschitz_constant = self.fixed_lipschitz_constant
-            log_evaluations("Before", 92, local_penalization_acquisition, x_batch)
             local_penalization_acquisition.update_batches(np.concatenate(x_batch, axis=0), lipschitz_constant, f_min)
-            log_evaluations("After ", 94, local_penalization_acquisition, x_batch)
         return np.concatenate(x_batch, axis=0)
-
-
-def log_evaluations(when, line_no, lpa, x_batch):
-    import logging
-    msg1 = f"LPA.py:{line_no}: {when} update_batches: "
-    msg2 = " ".join([f"{float(lpa.evaluate(x)):7.4f}" for x in x_batch])
-    logging.info(msg1 + msg2)
 
 
 def _estimate_lipschitz_constant(space: ParameterSpace, model: IDifferentiable):

--- a/emukit/core/acquisition/integrated_acquisition.py
+++ b/emukit/core/acquisition/integrated_acquisition.py
@@ -28,7 +28,7 @@ class IntegratedHyperParameterAcquisition(Acquisition):
         self.subsample_interval = subsample_interval
         self.step_size = step_size
         self.leapfrog_steps = leapfrog_steps
-
+        self.update_batches_args = None
         self.update_parameters()
 
         acquisition = self.acquisition_generator(model)
@@ -43,7 +43,7 @@ class IntegratedHyperParameterAcquisition(Acquisition):
         acquisition_value = 0
         for sample in self.samples:
             self.model.fix_model_hyperparameters(sample)
-            acquisition = self.acquisition_generator(self.model)
+            acquisition = self.generate_and_possibly_update_batches()
             acquisition_value += acquisition.evaluate(x)
 
         return acquisition_value / self.n_samples
@@ -64,7 +64,7 @@ class IntegratedHyperParameterAcquisition(Acquisition):
 
         for sample in self.samples:
             self.model.fix_model_hyperparameters(sample)
-            acquisition = self.acquisition_generator(self.model)
+            acquisition = self.generate_and_possibly_update_batches()
             improvement_sample, d_improvement_dx_sample = acquisition.evaluate_with_gradients(x)
             acquisition_value += improvement_sample
             d_acquisition_dx += d_improvement_dx_sample
@@ -82,5 +82,18 @@ class IntegratedHyperParameterAcquisition(Acquisition):
         return self._has_gradients
 
     def update_batches(self, x_batch, lipschitz_constant, f_min):
+        self.update_batches_args = (x_batch, lipschitz_constant, f_min)
+        import logging
+        logging.info(f"integrated_acquisition.py:87: self.update_batches_args set, self is {self}")
+        #acquisition = self.acquisition_generator(self.model)
+        #acquisition.update_batches(x_batch, lipschitz_constant, f_min)
+
+    def generate_and_possibly_update_batches(self):
         acquisition = self.acquisition_generator(self.model)
-        acquisition.update_batches(x_batch, lipschitz_constant, f_min)
+        #import logging
+        if self.update_batches_args is not None:
+            #logging.info(f"integrated_acquisition.py:95: self.update_batches_args is NOT None, self is {self}")
+            acquisition.update_batches(*self.update_batches_args)
+        #else:
+            #logging.info(f"integrated_acquisition.py:98: self.update_batches_args is None, self is {self}")
+        return acquisition

--- a/tests/emukit/core/test_acquisition.py
+++ b/tests/emukit/core/test_acquisition.py
@@ -1,6 +1,7 @@
 import mock
 import numpy as np
 import pytest
+from emukit.bayesian_optimization.acquisitions.local_penalization import LocalPenalization
 
 from emukit.core.acquisition import Acquisition, IntegratedHyperParameterAcquisition
 from emukit.core.interfaces import IPriorHyperparameters
@@ -97,3 +98,21 @@ def test_integrated_acquisition_gradients():
     mock_acquisition.has_gradients = True
     acq = IntegratedHyperParameterAcquisition(mock_model, mock_acquisition_generator)
     assert acq.has_gradients == True
+
+
+def test_integrated_acquisition_update_batches():
+    """
+    Check that when IntegratedHyperParameterAcquisition.update_batches is called, the
+    same arguments are passed to the update_batches method of the Acquisition object(s)
+    returned by its acquisition generator when IntegratedHyperParameterAcquisition.evaluate
+    is called.
+    """
+    mock_model = mock.create_autospec(IPriorHyperparameters)
+    mock_acquisition = mock.create_autospec(LocalPenalization)
+    mock_acquisition_generator = lambda x: mock_acquisition
+    acq = IntegratedHyperParameterAcquisition(mock_model, mock_acquisition_generator)
+    acq.update_batches([], 1.0, 0.5)
+    acq.samples = [None]
+    acq.n_samples = 1
+    acq.evaluate(np.zeros(1))
+    mock_acquisition.update_batches.assert_called_with([], 1.0, 0.5)


### PR DESCRIPTION
This PR fixes the following problem: IntegratedHyperParameterAcquisition.update_batches was not doing what it should, because it was calling update_batches on a newly-minted Acquisition object which it immediately threw away. Then, later Acquisition objects were not having update_batches applied to them. With this PR, update_batches saves its argument as an attribute, and a new method generate_acquisition_with_batch_update creates the Acquisition object and then calls update_batches on it with the values stored in the attribute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
