### PR TITLE
Fix output dimensions of ES for 1 point input case

### DIFF
--- a/emukit/bayesian_optimization/acquisitions/entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/entropy_search.py
@@ -190,7 +190,7 @@ class EntropySearch(Acquisition):
 
         new_entropy = np.mean(H_p)
         entropy_change = new_entropy - self.p_min_entropy
-        return np.array([[entropy_change]])
+        return entropy_change.reshape(-1, 1)
 
     def _innovations(self, x: np.ndarray) -> tuple:
         """

--- a/emukit/bayesian_optimization/acquisitions/max_value_entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/max_value_entropy_search.py
@@ -161,7 +161,7 @@ class MUMBO(MaxValueEntropySearch):
         information about the objective function
         See this paper for more details:
         Moss et al.
-        MUMBO: MUlti-task Max-value Bayesian Optimsiation
+        MUMBO: MUlti-task Max-value Bayesian Optimisation
         ECML 2020
 
         :param model: GP model to compute the distribution of the minimum dubbed pmin.
@@ -169,7 +169,7 @@ class MUMBO(MaxValueEntropySearch):
         :param target_information_source_index: The index of the information source we want to minimise
         :param num_samples: integer determining how many samples to draw of the minimum (does not need to be large)
         :param grid_size: number of random locations in grid used to fit the gumbel distribution and approximately generate
-        the samples of the minimum (recommend scaling with problem dimension, i.e. 10000*d)
+                          the samples of the minimum (recommend scaling with problem dimension, i.e. 10000*d)
         """
 
         if not isinstance(model, IEntropySearchModel):


### PR DESCRIPTION
*Issue #, if available:* #387

*Description of changes:* ES acquistion function turned out to be handling output shapes weirdly, which resulted in wrong shapes for the case when only one point was given as input. This PR fixes that, and adds few unit tests to validate shapes better.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
