### PR TITLE
Remove confusing defaults for running tests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -31,7 +31,7 @@ jobs:
           pip install .
       - name: Run coverage
         run: |
-          python -m pytest
+          python -m pytest --verbose --cov emukit --cov-report term-missing tests
       - name: Run codecov
         if: success()
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,10 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Unit tests
       run: |
-        python -m pytest
+        python -m pytest tests
     - name: Integration tests
       run: |
-        pytest -c /dev/null integration_tests
+        python -m pytest integration_tests
 
   os_versions:
 
@@ -67,4 +67,4 @@ jobs:
         pip install .
     - name: Unit tests
       run: |
-        python -m pytest
+        python -m pytest tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,11 +81,21 @@ Before submitting the pull request, please go through this checklist to make the
 See installing from source.
 
 ### Running tests
-Run the full suite of tests by running:
+Run the full suite of unit tests or integration tests with these commands:
 ```
-python -m pytest
+pytest tests
+pytest integration_tests
 ```
-from the top level directory. This also does coverage checks.
+from the top level directory. To check unit test coverage, run this:
+```
+pytest --verbose --cov emukit --cov-report term-missing tests
+```
+
+Notice that unit tests and integration tests have their own set of additional dependencies. Those can be found in the `requirements` folder, and installed with:
+```
+pip install -r requirements/test_requirements.txt
+pip install -r requirements/integration_test_requirements.txt
+```
 
 ### Generating docs
 Documentation contributions are much appreciated! If you see something incorrect or poorly explained, feel free to fix it and send the update!

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,17 +1,10 @@
 [metadata]
 description-file = README.md
 
-[tool:pytest]
-addopts =
-    --verbose
-    --cov emukit
-    --cov-report term-missing
-    tests
-
 [coverage:run]
 branch = true
 source = emukit
-omit = ./tests/*.py, setup.py, ./emukit/examples/*.py
+omit = ./tests/*.py, setup.py, ./emukit/examples/*.py, ./integration_tests/*.py
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
*Issue #, if available:* #340

*Description of changes:* We had some defaults for running pytest that were often getting in a way of running tests. Getting rid of them!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
