### PR TITLE
Cleaning up acquisition tests in `quadrature`

### DIFF
--- a/tests/emukit/quadrature/ground_truth_integrals_bounded_bq.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_bounded_bq.py
@@ -1,7 +1,5 @@
 # Use this script for ground truth integrals of the Bounded BQ Gaussian process.
 
-from typing import List, Tuple
-
 import GPy
 import numpy as np
 

--- a/tests/emukit/quadrature/test_quadrature_acquisitions.py
+++ b/tests/emukit/quadrature/test_quadrature_acquisitions.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from math import isclose
-
 import GPy
 import numpy as np
 import pytest
+from pytest_lazyfixture import lazy_fixture
+from utils import check_grad
 
 from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, RBFGPy
 from emukit.quadrature.acquisitions import IntegralVarianceReduction, MutualInformation, UncertaintySampling
@@ -14,41 +14,67 @@ from emukit.quadrature.kernels.integration_measures import IsotropicGaussianMeas
 from emukit.quadrature.kernels.quadrature_rbf import QuadratureRBFIsoGaussMeasure, QuadratureRBFLebesgueMeasure
 from emukit.quadrature.methods import VanillaBayesianQuadrature
 
-REL_TOL = 1e-5
-ABS_TOL = 1e-4
-
 
 @pytest.fixture
-def model():
+def gpy_model():
     rng = np.random.RandomState(42)
     x_init = rng.rand(5, 2)
     y_init = rng.rand(5, 1)
-
     gpy_kernel = GPy.kern.RBF(input_dim=x_init.shape[1])
     gpy_model = GPy.models.GPRegression(X=x_init, Y=y_init, kernel=gpy_kernel)
-    qrbf = QuadratureRBFLebesgueMeasure(RBFGPy(gpy_kernel), integral_bounds=x_init.shape[1] * [(-3, 3)])
+    return gpy_model
+
+
+@pytest.fixture
+def model(gpy_model):
+    x_init, y_init = gpy_model.X, gpy_model.Y
+    qrbf = QuadratureRBFLebesgueMeasure(RBFGPy(gpy_model.kern), integral_bounds=x_init.shape[1] * [(-3, 3)])
     basegp = BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model)
-    model = VanillaBayesianQuadrature(base_gp=basegp, X=x_init, Y=y_init)
-    return model
+    return VanillaBayesianQuadrature(base_gp=basegp, X=x_init, Y=y_init)
 
 
 @pytest.fixture
-def model_with_density():
-    rng = np.random.RandomState(42)
-    x_init = rng.rand(5, 2)
-    y_init = rng.rand(5, 1)
-
-    gpy_kernel = GPy.kern.RBF(input_dim=x_init.shape[1])
-    gpy_model = GPy.models.GPRegression(X=x_init, Y=y_init, kernel=gpy_kernel)
+def model_with_density(gpy_model):
+    x_init, y_init = gpy_model.X, gpy_model.Y
     measure = IsotropicGaussianMeasure(mean=np.arange(x_init.shape[1]), variance=2.0)
-    qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_kernel), measure=measure)
+    qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
     basegp = BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model)
-    model = VanillaBayesianQuadrature(base_gp=basegp, X=x_init, Y=y_init)
-    return model
+    return VanillaBayesianQuadrature(base_gp=basegp, X=x_init, Y=y_init)
 
 
-def test_mutual_information_shapes(model):
-    aq = MutualInformation(model)
+# === acquisition fixtures start here
+
+
+@pytest.fixture
+def mutual_information(model):
+    return MutualInformation(model)
+
+
+@pytest.fixture
+def integral_variance_reduction(model):
+    return IntegralVarianceReduction(model)
+
+
+@pytest.fixture
+def uncertainty_sampling(model):
+    return UncertaintySampling(model)
+
+
+@pytest.fixture
+def uncertainty_sampling_density(model_with_density):
+    return UncertaintySampling(model_with_density)
+
+
+acquisitions_test_list = [
+    lazy_fixture("mutual_information"),
+    lazy_fixture("integral_variance_reduction"),
+    lazy_fixture("uncertainty_sampling"),
+    lazy_fixture("uncertainty_sampling_density"),
+]
+
+
+@pytest.mark.parametrize("aq", acquisitions_test_list)
+def test_quadrature_acquisition_shapes(aq):
     x = np.array([[-1, 1], [0, 0], [-2, 0.1]])
 
     # value
@@ -61,85 +87,8 @@ def test_mutual_information_shapes(model):
     assert res[1].shape == (3, 2)
 
 
-def test_integral_variance_reduction_shapes(model):
-    aq = IntegralVarianceReduction(model)
-    x = np.array([[-1, 1], [0, 0], [-2, 0.1]])
-
-    # value
-    res = aq.evaluate(x)
-    assert res.shape == (3, 1)
-
-    # gradient
-    res = aq.evaluate_with_gradients(x)
-    assert res[0].shape == (3, 1)
-    assert res[1].shape == (3, 2)
-
-
-def test_uncertainty_sampling_shapes(model, model_with_density):
-    # test both with Lebesgue measure and with a probability measure because the gradients are computed differently
-    x = np.array([[-1, 1], [0, 0], [-2, 0.1]])
-
-    aq = UncertaintySampling(model)
-    aq_with_density = UncertaintySampling(model_with_density)
-
-    # value
-    res = aq.evaluate(x)
-    assert res.shape == (3, 1)
-
-    # gradient
-    res = aq.evaluate_with_gradients(x)
-    assert res[0].shape == (3, 1)
-    assert res[1].shape == (3, 2)
-
-    # value
-    res = aq_with_density.evaluate(x)
-    assert res.shape == (3, 1)
-
-    # gradient
-    res = aq_with_density.evaluate_with_gradients(x)
-    assert res[0].shape == (3, 1)
-    assert res[1].shape == (3, 2)
-
-
-def test_mutual_information_gradients(model):
-    aq = MutualInformation(model)
-    x = np.array([[-2.5, 1.5]])
-    _check_grad(aq, x)
-
-
-def test_integral_variance_reduction_gradients(model):
-    aq = IntegralVarianceReduction(model)
-    x = np.array([[-2.5, 1.5]])
-    _check_grad(aq, x)
-
-
-def test_uncertainty_sampling_gradients(model, model_with_density):
-    aq = UncertaintySampling(model)
-    aq_with_density = UncertaintySampling(model_with_density)
-    x = np.array([[-2.5, 1.5]])
-    _check_grad(aq, x)
-    _check_grad(aq_with_density, x)
-
-
-def _compute_numerical_gradient(aq, x, eps=1e-6):
-    f, grad = aq.evaluate_with_gradients(x)
-    grad_num = np.zeros(grad.shape)
-    for d in range(x.shape[1]):
-        x_tmp = x.copy()
-        x_tmp[:, d] = x_tmp[:, d] + eps
-        f_tmp = aq.evaluate(x_tmp)
-        grad_num_d = (f_tmp - f) / eps
-        grad_num[:, d] = grad_num_d[:, 0]
-    return grad, grad_num
-
-
-def _check_grad(aq, x):
-    grad, grad_num = _compute_numerical_gradient(aq, x)
-    isclose_all = 1 - np.array(
-        [
-            isclose(grad[i, j], grad_num[i, j], rel_tol=REL_TOL, abs_tol=ABS_TOL)
-            for i in range(grad.shape[0])
-            for j in range(grad.shape[1])
-        ]
-    )
-    assert isclose_all.sum() == 0
+@pytest.mark.parametrize("aq", acquisitions_test_list)
+def test_quadrature_acquisition_gradient_values(aq):
+    func = lambda x: aq.evaluate(x)[:, 0]
+    dfunc = lambda x: aq.evaluate_with_gradients(x)[1].T
+    check_grad(func, dfunc, in_shape=(3, 2))

--- a/tests/emukit/quadrature/utils.py
+++ b/tests/emukit/quadrature/utils.py
@@ -1,0 +1,33 @@
+"""Helper functions for quadrature tests"""
+
+from math import isclose
+
+import numpy as np
+
+
+def _compute_numerical_gradient(func, dfunc, in_shape):
+    """Dimension that is being varied must be last dimension."""
+    eps = 1e-8
+    x = np.random.randn(*in_shape)
+    f = func(x)
+    df = dfunc(x)
+    dft = np.zeros(df.shape)
+    for d in range(x.shape[-1]):
+        x_tmp = x.copy()
+        x_tmp[..., d] = x_tmp[..., d] + eps
+        f_tmp = func(x_tmp)
+        dft_d = (f_tmp - f) / eps
+        dft[d, ...] = dft_d
+    return df, dft
+
+
+def check_grad(func, dfunc, in_shape):
+    """``func`` must return ``np.ndarray`` of shape ``s`` and ``dfunc`` must return
+    ``np.ndarray`` of shape ``s + (input_dim, )``."""
+    ABS_TOL = 1e-4
+    REL_TOL = 1e-5
+    df, dft = _compute_numerical_gradient(func, dfunc, in_shape)
+    isclose_all = np.array(
+        [isclose(grad1, grad2, rel_tol=REL_TOL, abs_tol=ABS_TOL) for grad1, grad2 in zip(df.flatten(), dft.flatten())]
+    )
+    assert (1 - isclose_all).sum() == 0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a a lot of duplicate code in the tests for `quadrature` acquisitions which made it hard to add a new acquisition function to the tests. This PR parameterize said tests. It is straightforward now to run all tests on a new acquisition function simply by adding a new fixture to the list.

Tests themselves are unchanged. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
