### PR TITLE
Brownian motion `quadrature` kernel and GPy wrapper

### DIFF
--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -238,7 +238,7 @@ class BrownianGPy(IBrownian):
     r"""Wrapper of the GPy Brownian motion kernel as required for some EmuKit quadrature methods.
 
     .. math::
-        k(x, x') = \sigma^2 \operatorname{min}(x, x'),
+        k(x, x') = \sigma^2 \operatorname{min}(x, x')\quad\text{with}\quad x, x' \geq 0,
 
     where :math:`\sigma^2` is the ``variance`` property.
 

--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -1,3 +1,5 @@
+"""GPy wrappers for the quadrature package."""
+
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,17 +10,17 @@ import GPy
 import numpy as np
 from scipy.linalg import lapack
 
-from emukit.quadrature.interfaces import IBaseGaussianProcess
-from emukit.quadrature.interfaces.standard_kernels import IRBF, IProductMatern32
-from emukit.quadrature.kernels import (
+from ..quadrature.interfaces import IRBF, IBaseGaussianProcess, IBrownian, IProductMatern32
+from ..quadrature.kernels import (
+    QuadratureBrownianLebesgueMeasure,
     QuadratureKernel,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureRBFIsoGaussMeasure,
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
-from emukit.quadrature.measures import IntegrationMeasure, IsotropicGaussianMeasure, UniformMeasure
-from emukit.quadrature.typing import BoundsType
+from ..quadrature.measures import IntegrationMeasure, IsotropicGaussianMeasure, UniformMeasure
+from ..quadrature.typing import BoundsType
 
 
 class BaseGaussianProcessGPy(IBaseGaussianProcess):
@@ -119,12 +121,6 @@ class RBFGPy(IRBF):
 
     def K(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
         return self.gpy_rbf.K(x1, x2)
-
-    def dK_dx1(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
-        K = self.K(x1, x2)
-        scaled_vector_diff = (x1.T[:, :, None] - x2.T[:, None, :]) / self.lengthscale**2
-        dK_dx1 = -K[None, ...] * scaled_vector_diff
-        return dK_dx1
 
 
 class ProductMatern32GPy(IProductMatern32):
@@ -227,21 +223,37 @@ class ProductMatern32GPy(IProductMatern32):
 
     def dK_dx1(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
         if isinstance(self.gpy_matern, GPy.kern.Matern32):
-            return self._dK_dx_1d(x1[:, 0], x2[:, 0], self.gpy_matern)[None, :, :]
+            return self._dK_dx1_1d(x1[:, 0], x2[:, 0], self.gpy_matern.lengthscale[0])[None, :, :]
 
         # product kernel
         dK_dx1 = np.ones([x1.shape[1], x1.shape[0], x2.shape[0]])
         for dim, kern in enumerate(self.gpy_matern.parameters):
             prod_term = self._K_from_prod(x1, x2, skip=[dim])  # N x M
-            grad_term = self._dK_dx_1d(x1[:, dim], x2[:, dim], kern)  # N x M
+            grad_term = self._dK_dx1_1d(x1[:, dim], x2[:, dim], kern.lengthscale[0])  # N x M
             dK_dx1[dim, :, :] *= prod_term * grad_term
         return dK_dx1
 
-    def _dK_dx_1d(self, x1: np.ndarray, x2: np.ndarray, kern: GPy.kern.Matern32) -> np.ndarray:
-        r = (x1.T[:, None] - x2.T[None, :]) / kern.lengthscale[0]  # N x M
-        dr_dx1 = r / (kern.lengthscale[0] * abs(r))
-        dK_dr = -3 * abs(r) * np.exp(-np.sqrt(3) * abs(r))
-        return dK_dr * dr_dx1
+
+class BrownianGPy(IBrownian):
+    r"""Wrapper of the GPy Brownian motion kernel as required for some EmuKit quadrature methods.
+
+    .. math::
+        k(x, x') = \sigma^2 \operatorname{min}(x, x'),
+
+    where :math:`\sigma^2` is the ``variance`` property.
+
+    :param gpy_brownian: A Brownian motion kernel from GPy.
+    """
+
+    def __init__(self, gpy_brownian: GPy.kern.Brownian):
+        self.gpy_brownian = gpy_brownian
+
+    @property
+    def variance(self) -> np.float:
+        return self.gpy_brownian.variance[0]
+
+    def K(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+        return self.gpy_brownian.K(x1, x2)
 
 
 def create_emukit_model_from_gpy_model(
@@ -289,11 +301,36 @@ def create_emukit_model_from_gpy_model(
         quadrature_kernel_emukit = _get_qkernel_matern32(
             standard_kernel_emukit, integral_bounds, measure, integral_name
         )
+    # Brownian
+    elif isinstance(gpy_model.kern, GPy.kern.Brownian):
+        standard_kernel_emukit = BrownianGPy(gpy_model.kern)
+        quadrature_kernel_emukit = _get_qkernel_brownian(
+            standard_kernel_emukit, integral_bounds, measure, integral_name
+        )
     else:
-        raise ValueError("Only RBF and ProductMatern32 kernel are supported. Got ", gpy_model.kern.name, " instead.")
+        raise ValueError(f"There is no GPy wrapper for the provided kernel ({gpy_model.kern.name}).")
 
     # wrap the base-gp model
     return BaseGaussianProcessGPy(kern=quadrature_kernel_emukit, gpy_model=gpy_model)
+
+
+def _get_qkernel_brownian(
+    standard_kernel_emukit: IBrownian,
+    integral_bounds: Optional[BoundsType],
+    measure: Optional[IntegrationMeasure],
+    integral_name: str,
+):
+    # we already know that either bounds or measure is given (or both)
+    # finite bounds, standard Lebesgue measure
+    if (integral_bounds is not None) and (measure is None):
+        quadrature_kernel_emukit = QuadratureBrownianLebesgueMeasure(
+            brownian_kernel=standard_kernel_emukit, integral_bounds=integral_bounds, variable_names=integral_name
+        )
+
+    else:
+        raise ValueError("Currently only standard Lebesgue measure (measure=None) is supported.")
+
+    return quadrature_kernel_emukit
 
 
 def _get_qkernel_matern32(

--- a/emukit/quadrature/acquisitions/mutual_information.py
+++ b/emukit/quadrature/acquisitions/mutual_information.py
@@ -31,6 +31,7 @@ class MutualInformation(Acquisition):
     """
 
     def __init__(self, model: VanillaBayesianQuadrature):
+        self.model = model
         self.rho2 = SquaredCorrelation(model)
 
     def has_gradients(self) -> bool:

--- a/emukit/quadrature/interfaces/__init__.py
+++ b/emukit/quadrature/interfaces/__init__.py
@@ -5,11 +5,12 @@
 
 
 from .base_gp import IBaseGaussianProcess  # noqa: F401
-from .standard_kernels import IRBF, IProductMatern32, IStandardKernel  # noqa: F401
+from .standard_kernels import IRBF, IBrownian, IProductMatern32, IStandardKernel  # noqa: F401
 
 __all__ = [
     "IBaseGaussianProcess",
     "IStandardKernel",
+    "IBrownian",
     "IRBF",
     "IProductMatern32",
 ]

--- a/emukit/quadrature/interfaces/standard_kernels.py
+++ b/emukit/quadrature/interfaces/standard_kernels.py
@@ -17,9 +17,9 @@ class IStandardKernel:
     def K(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
         """The kernel k(x1, x2) evaluated at x1 and x2.
 
-        :param x1: First argument of the kernel.
-        :param x2: Second argument of the kernel.
-        :returns: Kernel evaluated at x1, x2.
+        :param x1: First argument of the kernel, shape (n_points N, input_dim)
+        :param x2: Second argument of the kernel, shape (n_points M, input_dim)
+        :returns: Kernel evaluated at x1, x2, shape (N, M).
         """
         raise NotImplementedError
 
@@ -27,8 +27,8 @@ class IStandardKernel:
     def dK_dx1(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
         """Gradient of the kernel wrt x1 evaluated at pair x1, x2.
 
-        :param x1: First argument of the kernel, shape = (n_points N, input_dim)
-        :param x2: Second argument of the kernel, shape = (n_points M, input_dim)
+        :param x1: First argument of the kernel, shape (n_points N, input_dim)
+        :param x2: Second argument of the kernel, shape (n_points M, input_dim)
         :return: The gradient of the kernel wrt x1 evaluated at (x1, x2), shape (input_dim, N, M)
         """
         raise NotImplementedError
@@ -73,6 +73,12 @@ class IRBF(IStandardKernel):
     def variance(self) -> np.float:
         r"""The scale :math:`\sigma^2` of the kernel."""
         raise NotImplementedError
+
+    def dK_dx1(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+        K = self.K(x1, x2)
+        scaled_vector_diff = (x1.T[:, :, None] - x2.T[:, None, :]) / self.lengthscale**2
+        dK_dx1 = -K[None, ...] * scaled_vector_diff
+        return dK_dx1
 
     def dKdiag_dx(self, x: np.ndarray) -> np.ndarray:
         return np.zeros((x.shape[1], x.shape[0]))
@@ -121,5 +127,53 @@ class IProductMatern32(IStandardKernel):
         r"""The scale :math:`\sigma^2` of the kernel."""
         raise NotImplementedError
 
+    def _dK_dx1_1d(self, x1: np.ndarray, x2: np.ndarray, ell: float) -> np.ndarray:
+        """Unscaled gradient of 1D Matern32 where ``ell`` is the lengthscale parameter.
+
+        This method can be used in case the product Matern32 is implemented via a List of univariate Matern32.
+
+        :param x1: First argument of the kernel, shape = (n_points N,)
+        :param x2: Second argument of the kernel, shape = (n_points M,)
+        :param ell: The lengthscale of the 1D Matern32.
+        :return: The gradient of the kernel wrt x1 evaluated at (x1, x2), shape (N, M).
+        """
+        r = (x1.T[:, None] - x2.T[None, :]) / ell  # N x M
+        dr_dx1 = r / (ell * abs(r))
+        dK_dr = -3 * abs(r) * np.exp(-np.sqrt(3) * abs(r))
+        return dK_dr * dr_dx1
+
     def dKdiag_dx(self, x: np.ndarray) -> np.ndarray:
         return np.zeros((x.shape[1], x.shape[0]))
+
+
+class IBrownian(IStandardKernel):
+    r"""Interface for a Brownian motion kernel.
+
+    .. math::
+        k(x, x') = \sigma^2 \operatorname{min}(x, x'),
+
+    where :math:`\sigma^2` is the ``variance`` property.
+
+    .. note::
+        Inherit from this class to wrap your standard Brownian motion kernel.
+        The wrapped kernel can then be handed to a quadrature Brownian motion kernel that
+        augments it with integrability.
+
+    .. seealso::
+       * :class:`emukit.quadrature.kernels.QuadratureBrownian`
+       * :class:`emukit.quadrature.kernels.QuadratureBrownianLebesgueMeasure`
+
+    """
+
+    @property
+    def variance(self) -> np.float:
+        r"""The scale :math:`\sigma^2` of the kernel."""
+        raise NotImplementedError
+
+    def dK_dx1(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+        x1_rep = np.repeat(x1[:, 0][np.newaxis, ...], x2.shape[0], axis=0).T
+        x2_rep = np.repeat(x2[:, 0][np.newaxis, ...], x1.shape[0], axis=0)
+        return self.variance * (x1_rep < x2_rep)[np.newaxis, :, :]
+
+    def dKdiag_dx(self, x: np.ndarray) -> np.ndarray:
+        return self.variance * np.ones((x.shape[1], x.shape[0]))

--- a/emukit/quadrature/interfaces/standard_kernels.py
+++ b/emukit/quadrature/interfaces/standard_kernels.py
@@ -150,7 +150,7 @@ class IBrownian(IStandardKernel):
     r"""Interface for a Brownian motion kernel.
 
     .. math::
-        k(x, x') = \sigma^2 \operatorname{min}(x, x'),
+        k(x, x') = \sigma^2 \operatorname{min}(x, x')\quad\text{with}\quad x, x' \geq 0,
 
     where :math:`\sigma^2` is the ``variance`` property.
 

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from .quadrature_kernels import QuadratureKernel
+from .quadrature_kernels import QuadratureKernel  # isort:skip
 from .quadrature_brownian import QuadratureBrownian, QuadratureBrownianLebesgueMeasure
 from .quadrature_matern32 import QuadratureProductMatern32, QuadratureProductMatern32LebesgueMeasure
 from .quadrature_rbf import (

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from .quadrature_kernels import QuadratureKernel  # noqa: F401
+from .quadrature_kernels import QuadratureKernel
+from .quadrature_brownian import QuadratureBrownian, QuadratureBrownianLebesgueMeasure
 from .quadrature_matern32 import QuadratureProductMatern32, QuadratureProductMatern32LebesgueMeasure
 from .quadrature_rbf import (
     QuadratureRBF,
@@ -15,6 +16,8 @@ from .quadrature_rbf import (
 
 __all__ = [
     "QuadratureKernel",
+    "QuadratureBrownian",
+    "QuadratureBrownianLebesgueMeasure",
     "QuadratureRBF",
     "QuadratureRBFLebesgueMeasure",
     "QuadratureRBFUniformMeasure",

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -1,0 +1,122 @@
+"""The Brownian motion kernel embeddings."""
+
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import Optional, Union
+
+import numpy as np
+
+from ...quadrature.interfaces.standard_kernels import IBrownian
+from ..kernels import QuadratureKernel
+from ..measures import BoxDomain, IntegrationMeasure
+from ..typing import BoundsType
+
+
+class QuadratureBrownian(QuadratureKernel):
+    r"""A Brownian motion kernel augmented with integrability.
+
+    .. math::
+        k(x, x') = \sigma^2 \operatorname{min}(x, x'),
+
+    where :math:`\sigma^2` is the ``variance`` property.
+
+    .. note::
+        This class is compatible with the standard kernel :class:`IBrownian`.
+        Each child of this class implements an embedding w.r.t. a specific integration measure.
+
+    .. seealso::
+       * :class:`emukit.quadrature.interfaces.IBrownian`
+       * :class:`emukit.quadrature.kernels.QuadratureKernel`
+
+    :param brownian_kernel: The standard EmuKit Brownian motion kernel.
+    :param integral_bounds: The integral bounds.
+                            List of D tuples, where D is the dimensionality
+                            of the integral and the tuples contain the lower and upper bounds of the integral
+                            i.e., [(lb_1, ub_1), (lb_2, ub_2), ..., (lb_D, ub_D)].
+                            ``None`` if bounds are infinite.
+    :param measure: The integration measure. ``None`` implies the standard Lebesgue measure.
+    :param variable_names: The (variable) name(s) of the integral.
+
+    :raises ValueError: If ``integral_bounds`` have wrong length.
+
+    """
+
+    def __init__(
+        self,
+        brownian_kernel: IBrownian,
+        integral_bounds: Optional[BoundsType],
+        measure: Optional[IntegrationMeasure],
+        variable_names: str = "",
+    ) -> None:
+
+        if integral_bounds is not None:
+            if len(integral_bounds) != 1:
+                raise ValueError("Integral bounds for Brownian motion kernel must be 1-dimensional.")
+
+        super().__init__(
+            kern=brownian_kernel, integral_bounds=integral_bounds, measure=measure, variable_names=variable_names
+        )
+
+    @property
+    def variance(self) -> float:
+        r"""The scale :math:`\sigma^2` of the kernel."""
+        return self.kern.variance
+
+    def qK(self, x2: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def Kq(self, x1: np.ndarray) -> np.ndarray:
+        return self.qK(x1).T
+
+    def qKq(self) -> float:
+        raise NotImplementedError
+
+    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
+        return self.dqK_dx(x1).T
+
+
+class QuadratureBrownianLebesgueMeasure(QuadratureBrownian):
+    """A Brownian motion kernel augmented with integrability w.r.t. the standard Lebesgue measure.
+
+    .. seealso::
+       * :class:`emukit.quadrature.interfaces.IBrownian`
+       * :class:`emukit.quadrature.kernels.QuadratureBrownian`
+
+    :param brownian_kernel: The standard EmuKit Brownian motion kernel.
+    :param integral_bounds: The integral bounds.
+                            List of D tuples, where D is the dimensionality
+                            of the integral and the tuples contain the lower and upper bounds of the integral
+                            i.e., [(lb_1, ub_1), (lb_2, ub_2), ..., (lb_D, ub_D)].
+                            ``None`` if bounds are infinite.
+    :param variable_names: The (variable) name(s) of the integral.
+
+    """
+
+    def __init__(self, brownian_kernel: IBrownian, integral_bounds: BoundsType, variable_names: str = "") -> None:
+        super().__init__(
+            brownian_kernel=brownian_kernel,
+            integral_bounds=integral_bounds,
+            measure=None,
+            variable_names=variable_names,
+        )
+
+    def qK(self, x2: np.ndarray) -> np.ndarray:
+        lb = self.integral_bounds.lower_bounds
+        ub = self.integral_bounds.upper_bounds
+        kernel_mean = ub * x2 - 0.5 * x2**2 - 0.5 * lb**2
+        return self.variance * kernel_mean.T
+
+    def qKq(self) -> float:
+        lb = self.integral_bounds.lower_bounds[0, 0]
+        ub = self.integral_bounds.upper_bounds[0, 0]
+        qKq = 0.5 * ub * (ub**2 - lb**2) - (ub**3 - lb**3) / 6 - 0.5 * lb**2 * (ub - lb)
+        return float(self.variance * qKq)
+
+    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
+        ub = self.integral_bounds.upper_bounds
+        return self.variance * (ub - x2).T

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -18,7 +18,7 @@ class QuadratureBrownian(QuadratureKernel):
     r"""A Brownian motion kernel augmented with integrability.
 
     .. math::
-        k(x, x') = \sigma^2 \operatorname{min}(x, x'),
+        k(x, x') = \sigma^2 \operatorname{min}(x, x')\quad\text{with}\quad x, x' \geq 0,
 
     where :math:`\sigma^2` is the ``variance`` property.
 

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -25,7 +25,7 @@ class QuadratureKernel:
         :class:`IStandardKernel` is :class:`QuadratureRBF` and :class:`IRBF`. The kernel embeddings are
         implemented w.r.t. a specific integration measure, for example the :class:`LebesgueMeasure`.
 
-    :param kern: Standard emukit kernel.
+    :param kern: Standard EmuKit kernel.
     :param integral_bounds: The integral bounds.
                             List of D tuples, where D is the dimensionality
                             of the integral and the tuples contain the lower and upper bounds of the integral

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -49,16 +49,17 @@ class QuadratureKernel:
         # in this kernel will have infinite bounds still.
         if (integral_bounds is None) and (measure is None):
             raise ValueError("integral_bounds and measure are both None. At least one of them must be given.")
-        if integral_bounds is None:
-            reasonable_box_bounds = measure.get_box()
-            self.integral_bounds = None
-        else:
-            reasonable_box_bounds = integral_bounds
-            self.integral_bounds = BoxDomain(name=variable_names, bounds=integral_bounds)
 
-        self.reasonable_box = BoxDomain(name=variable_names, bounds=reasonable_box_bounds)
+        if integral_bounds is not None:
+            reasonable_box = BoxDomain(name=variable_names, bounds=integral_bounds)
+            integral_bounds = BoxDomain(name=variable_names, bounds=integral_bounds)
+        else:
+            reasonable_box = BoxDomain(name=variable_names, bounds=measure.get_box())
+
         self.kern = kern
         self.measure = measure
+        self.integral_bounds = integral_bounds
+        self.reasonable_box = reasonable_box
         self.input_dim = self.reasonable_box.dim
 
     def K(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -30,7 +30,7 @@ class QuadratureProductMatern32(QuadratureKernel):
        * :class:`emukit.quadrature.interfaces.IProductMatern32`
        * :class:`emukit.quadrature.kernels.QuadratureKernel`
 
-    :param matern_kernel: The standard emukit product Matern32 kernel.
+    :param matern_kernel: The standard EmuKit product Matern32 kernel.
     :param integral_bounds: The integral bounds.
                             List of D tuples, where D is the dimensionality
                             of the integral and the tuples contain the lower and upper bounds of the integral
@@ -90,7 +90,7 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32):
        * :class:`emukit.quadrature.interfaces.IProductMatern32`
        * :class:`emukit.quadrature.kernels.QuadratureProductMatern32`
 
-    :param matern_kernel: The standard emukit product Matern32 kernel.
+    :param matern_kernel: The standard EmuKit product Matern32 kernel.
     :param integral_bounds: The integral bounds.
                             List of D tuples, where D is the dimensionality
                             of the integral and the tuples contain the lower and upper bounds of the integral

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -32,7 +32,7 @@ class QuadratureRBF(QuadratureKernel):
        * :class:`emukit.quadrature.interfaces.IRBF`
        * :class:`emukit.quadrature.kernels.QuadratureKernel`
 
-    :param rbf_kernel: The standard emukit rbf-kernel.
+    :param rbf_kernel: The standard EmuKit rbf-kernel.
     :param integral_bounds: The integral bounds.
                             List of D tuples, where D is the dimensionality
                             of the integral and the tuples contain the lower and upper bounds of the integral
@@ -106,7 +106,7 @@ class QuadratureRBFLebesgueMeasure(QuadratureRBF):
        * :class:`emukit.quadrature.interfaces.IRBF`
        * :class:`emukit.quadrature.kernels.QuadratureRBF`
 
-    :param rbf_kernel: The standard emukit rbf-kernel.
+    :param rbf_kernel: The standard EmuKit rbf-kernel.
     :param integral_bounds: The integral bounds.
                             List of D tuples, where D is the dimensionality
                             of the integral and the tuples contain the lower and upper bounds of the integral
@@ -161,7 +161,7 @@ class QuadratureRBFIsoGaussMeasure(QuadratureRBF):
        * :class:`emukit.quadrature.kernels.QuadratureRBF`
        * :class:`emukit.quadrature.measures.IsotropicGaussianMeasure`
 
-    :param rbf_kernel: The standard emukit rbf-kernel.
+    :param rbf_kernel: The standard EmuKit rbf-kernel.
     :param measure: A Gaussian measure.
     :param variable_names: The (variable) name(s) of the integral.
 
@@ -197,7 +197,7 @@ class QuadratureRBFUniformMeasure(QuadratureRBF):
        * :class:`emukit.quadrature.kernels.QuadratureRBF`
        * :class:`emukit.quadrature.measures.UniformMeasure`
 
-    :param rbf_kernel: The standard emukit rbf-kernel.
+    :param rbf_kernel: The standard EmuKit rbf-kernel.
     :param integral_bounds: The integral bounds.
                             List of D tuples, where D is the dimensionality
                             of the integral and the tuples contain the lower and upper bounds of the integral

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -8,6 +8,7 @@ from typing import List, Tuple
 
 import numpy as np
 from test_quadrature_kernels import (
+    get_qbrownian_lebesque,
     get_qmatern32_lebesque,
     get_qrbf_gauss_iso,
     get_qrbf_lebesque,
@@ -115,7 +116,8 @@ if __name__ == "__main__":
 
     # === Choose KERNEL BELOW ======
     # KERNEL = 'rbf'
-    KERNEL = "matern32"
+    # KERNEL = "matern32"
+    KERNEL = "brownian"
     # === CHOOSE KERNEL ABOVE ======
 
     _e = "Kernel embedding not implemented."
@@ -133,6 +135,9 @@ if __name__ == "__main__":
     elif KERNEL == "matern32":
         if MEASURE_INTBOUNDS == "Lebesgue-finite":
             emukit_qkern, dat = get_qmatern32_lebesque()
+    elif KERNEL == "brownian":
+        if MEASURE_INTBOUNDS == "Lebesgue-finite":
+            emukit_qkern, dat = get_qbrownian_lebesque()
         else:
             raise ValueError(_e)
 

--- a/tests/emukit/quadrature/test_measures.py
+++ b/tests/emukit/quadrature/test_measures.py
@@ -19,6 +19,7 @@ class DataUniformMeasure:
     D = 2
     measure_bounds = [(-1, 2), (0, 1)]
     measure = UniformMeasure(bounds=measure_bounds)
+    dat_bounds = measure_bounds
 
 
 @dataclass
@@ -27,6 +28,7 @@ class DataGaussIsoMeasure:
     mean = np.arange(D)
     variance = 0.5
     measure = IsotropicGaussianMeasure(mean=mean, variance=variance)
+    dat_bounds = [(m - 2 * np.sqrt(0.5), m + 2 * np.sqrt(0.5)) for m in mean]
 
 
 @pytest.fixture()
@@ -50,10 +52,10 @@ measure_test_list = [
 
 @pytest.mark.parametrize("measure", measure_test_list)
 def test_measure_gradient_values(measure):
-    D, measure = measure.D, measure.measure
+    D, measure, dat_bounds = measure.D, measure.measure, measure.dat_bounds
     func = lambda x: measure.compute_density(x)
     dfunc = lambda x: measure.compute_density_gradient(x).T
-    check_grad(func, dfunc, in_shape=(3, D))
+    check_grad(func, dfunc, in_shape=(3, D), bounds=dat_bounds)
 
 
 @pytest.mark.parametrize("measure", measure_test_list)

--- a/tests/emukit/quadrature/test_quadrature_acquisitions.py
+++ b/tests/emukit/quadrature/test_quadrature_acquisitions.py
@@ -91,4 +91,4 @@ def test_quadrature_acquisition_shapes(aq):
 def test_quadrature_acquisition_gradient_values(aq):
     func = lambda x: aq.evaluate(x)[:, 0]
     dfunc = lambda x: aq.evaluate_with_gradients(x)[1].T
-    check_grad(func, dfunc, in_shape=(3, 2))
+    check_grad(func, dfunc, in_shape=(3, 2), bounds=aq.model.X.shape[1] * [(-3, 3)])

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -10,8 +10,10 @@ from pytest_lazyfixture import lazy_fixture
 from utils import check_grad, sample_uniform
 
 from emukit.model_wrappers.gpy_quadrature_wrappers import BrownianGPy, ProductMatern32GPy, RBFGPy
+from emukit.quadrature.interfaces import IStandardKernel
 from emukit.quadrature.kernels import (
     QuadratureBrownianLebesgueMeasure,
+    QuadratureKernel,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureRBFIsoGaussMeasure,
     QuadratureRBFLebesgueMeasure,
@@ -369,6 +371,15 @@ def test_qkernel_gradient_values(kernel_embedding):
     func = lambda x: emukit_qkernel.Kq(x).T
     dfunc = lambda x: emukit_qkernel.dKq_dx(x).T
     check_grad(func, dfunc, in_shape, dat_bounds)
+
+
+# == tests specific to base class start here
+
+
+def test_qkernel_raises():
+    # must provide either measure or bounds
+    with pytest.raises(ValueError):
+        QuadratureKernel(IStandardKernel(), integral_bounds=None, measure=None)
 
 
 # == tests specific to Brownian motion kernel starts here

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -369,3 +369,12 @@ def test_qkernel_gradient_values(kernel_embedding):
     func = lambda x: emukit_qkernel.Kq(x).T
     dfunc = lambda x: emukit_qkernel.dKq_dx(x).T
     check_grad(func, dfunc, in_shape, dat_bounds)
+
+
+# == tests specific to Brownian motion kernel starts here
+
+
+def test_brownian_qkernel_raises():
+    wrong_bounds = [(1, 2), (1, 2)]
+    with pytest.raises(ValueError):
+        QuadratureBrownianLebesgueMeasure(BrownianGPy(GPy.kern.Brownian()), integral_bounds=wrong_bounds)

--- a/tests/emukit/quadrature/test_quadrature_models.py
+++ b/tests/emukit/quadrature/test_quadrature_models.py
@@ -26,6 +26,7 @@ class DataGaussIso:
     # for bounded methods
     bound_lower = np.min(Y) - 0.5  # make sure bound is lower than the Y values
     bound_upper = np.max(Y) + 0.5  # make sure bound is larger than the Y values
+    dat_bounds = [(m - 2 * np.sqrt(2), m + 2 * np.sqrt(2)) for m in measure_mean]
 
 
 def get_gpy_model():
@@ -220,12 +221,12 @@ def test_warped_model_gradient_values(model, data):
     # gradient of mean
     func = lambda z: model.predict(z)[0][:, 0]
     dfunc = lambda z: model.get_prediction_gradients(z)[0].T
-    check_grad(func, dfunc, in_shape=(5, data.D))
+    check_grad(func, dfunc, in_shape=(5, data.D), bounds=data.dat_bounds)
 
     # gradient of var
     func = lambda z: model.predict(z)[1][:, 0]
     dfunc = lambda z: model.get_prediction_gradients(z)[1].T
-    check_grad(func, dfunc, in_shape=(5, data.D))
+    check_grad(func, dfunc, in_shape=(5, data.D), bounds=data.dat_bounds)
 
 
 @pytest.mark.parametrize(

--- a/tests/emukit/quadrature/utils.py
+++ b/tests/emukit/quadrature/utils.py
@@ -5,19 +5,22 @@ from typing import Callable, Tuple
 
 import numpy as np
 
+from emukit.quadrature.typing import BoundsType
+
 
 def _compute_numerical_gradient(
-    func: Callable, dfunc: Callable, in_shape: Tuple[int, ...]
+    func: Callable, dfunc: Callable, in_shape: Tuple[int, ...], bounds: BoundsType
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Computes the numerical gradient of ``func``.
 
     :param func: Function must take inputs of shape ``in_shape = s + (input_dim, )`` and return np.ndarray of shape ``s``.
     :param dfunc: Gradient of function to be tested. Must return np.ndarray of shape ``(input_dim) + s``.
     :param in_shape: The input shape to ``func``. Must be of form ``in_shape = s + (input_dim, )``.
+    :param bounds: The bounds for the x values.
     :return: The gradient ``dfunc`` evaluated at a random location and its numerical gradient.
     """
     eps = 1e-8
-    x = np.random.randn(*in_shape)
+    x = sample_uniform(in_shape, bounds)
     f = func(x)
     df = dfunc(x)
     dft = np.zeros(df.shape)
@@ -31,18 +34,32 @@ def _compute_numerical_gradient(
 
 
 def check_grad(
-    func: Callable, dfunc: Callable, in_shape: Tuple[int, ...], atol: float = 1e-4, rtol: float = 1e-5
+    func: Callable,
+    dfunc: Callable,
+    in_shape: Tuple[int, ...],
+    bounds: BoundsType,
+    atol: float = 1e-4,
+    rtol: float = 1e-5,
 ) -> None:
     """Asserts if the gradient of a function is close to its numerical gradient.
 
     :param func: Function must take inputs of shape ``in_shape = s + (input_dim, )`` and return np.ndarray of shape ``s``.
     :param dfunc: Gradient of function to be tested. Must return np.ndarray of shape ``(input_dim) + s``.
     :param in_shape: The input shape to ``func``. Must be of form ``in_shape = s + (input_dim, )``.
+    :param bounds: The bounds for the x values.
     :param atol: Absolute tolerance of the closeness check. Defaults to 1e-4.
     :param atol: Relative tolerance of the closeness check. Defaults to 1e-5.
     """
-    df, dft = _compute_numerical_gradient(func, dfunc, in_shape)
+    df, dft = _compute_numerical_gradient(func, dfunc, in_shape, bounds)
     isclose_all = np.array(
         [isclose(grad1, grad2, rel_tol=rtol, abs_tol=atol) for grad1, grad2 in zip(df.flatten(), dft.flatten())]
     )
     assert (1 - isclose_all).sum() == 0
+
+
+def sample_uniform(in_shape, bounds):
+    n_samples = np.prod(in_shape[:-1])
+    samples = np.zeros(in_shape)
+    for i, b in enumerate(bounds):
+        samples[..., i] = np.random.uniform(low=b[0], high=b[1], size=n_samples)
+    return samples


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds 
- kernel embeddings for the Brownian motion kernel w.r.t. Lebesgue measure.
- an EmuKit interface for this kernel.
- a GPy wrapper for said interface.
- the kernel is added to the tests (shape, value, gradient etc tests) by adding a fixture to the existing tests.
- some minor docstring adjustments.
- some minor fix in the `quadrature` gradient checks (the input values used would occasionally not obey the domain constraints; now they do.)
- 2 additional tests that check if the qkernels raise exceptions when provided with wrong input.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
