### PR TITLE
`ProductBrownian` kernel embedding w.r.t Lebesgue measure & GPy wrapper

### DIFF
--- a/emukit/model_wrappers/__init__.py
+++ b/emukit/model_wrappers/__init__.py
@@ -3,5 +3,11 @@
 
 
 from .gpy_model_wrappers import GPyModelWrapper, GPyMultiOutputWrapper  # noqa: F401
-from .gpy_quadrature_wrappers import BaseGaussianProcessGPy, ProductMatern32GPy, RBFGPy  # noqa: F401
+from .gpy_quadrature_wrappers import (  # noqa: F401
+    BaseGaussianProcessGPy,
+    BrownianGPy,
+    ProductMatern32GPy,
+    ProductMatern52GPy,
+    RBFGPy,
+)
 from .simple_gp_model import SimpleGaussianProcessModel  # noqa: F401

--- a/emukit/model_wrappers/__init__.py
+++ b/emukit/model_wrappers/__init__.py
@@ -3,11 +3,4 @@
 
 
 from .gpy_model_wrappers import GPyModelWrapper, GPyMultiOutputWrapper  # noqa: F401
-from .gpy_quadrature_wrappers import (  # noqa: F401
-    BaseGaussianProcessGPy,
-    BrownianGPy,
-    ProductMatern32GPy,
-    ProductMatern52GPy,
-    RBFGPy,
-)
 from .simple_gp_model import SimpleGaussianProcessModel  # noqa: F401

--- a/emukit/quadrature/interfaces/__init__.py
+++ b/emukit/quadrature/interfaces/__init__.py
@@ -5,7 +5,14 @@
 
 
 from .base_gp import IBaseGaussianProcess  # noqa: F401
-from .standard_kernels import IRBF, IBrownian, IProductMatern32, IProductMatern52, IProductBrownian, IStandardKernel  # noqa: F401
+from .standard_kernels import (  # noqa: F401
+    IRBF,
+    IBrownian,
+    IProductBrownian,
+    IProductMatern32,
+    IProductMatern52,
+    IStandardKernel,
+)
 
 __all__ = [
     "IBaseGaussianProcess",

--- a/emukit/quadrature/interfaces/__init__.py
+++ b/emukit/quadrature/interfaces/__init__.py
@@ -5,13 +5,14 @@
 
 
 from .base_gp import IBaseGaussianProcess  # noqa: F401
-from .standard_kernels import IRBF, IBrownian, IProductMatern32, IProductMatern52, IStandardKernel  # noqa: F401
+from .standard_kernels import IRBF, IBrownian, IProductMatern32, IProductMatern52, IProductBrownian, IStandardKernel  # noqa: F401
 
 __all__ = [
     "IBaseGaussianProcess",
     "IStandardKernel",
     "IBrownian",
     "IRBF",
+    "IProductBrownian",
     "IProductMatern32",
     "IProductMatern52",
 ]

--- a/emukit/quadrature/interfaces/standard_kernels.py
+++ b/emukit/quadrature/interfaces/standard_kernels.py
@@ -241,3 +241,52 @@ class IBrownian(IStandardKernel):
 
     def dKdiag_dx(self, x: np.ndarray) -> np.ndarray:
         return self.variance * np.ones((x.shape[1], x.shape[0]))
+
+
+class IProductBrownian(IStandardKernel):
+    r"""Interface for a Brownian product kernel.
+
+    Inherit from this class to wrap your ProductBrownian kernel.
+
+    The product kernel is of the form
+    :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
+
+    .. math::
+        k_i(x, x') = \operatorname{min}(x_i, x_i')\quad\text{with}\quad x_i, x_i' \geq 0,
+
+    :math:`d` is the input dimensionality,
+    and :math:`\sigma^2` is the ``variance`` property.
+
+    Make sure to encode only a single variance parameter, and not one for each individual :math:`k_i`.
+
+    .. note::
+        Inherit from this class to wrap your standard product Brownian kernel. The wrapped kernel can then be
+        handed to a quadrature product Brownian kernel that augments it with integrability.
+
+    .. seealso::
+       * :class:`emukit.quadrature.kernels.QuadratureProductBrownian`
+       * :class:`emukit.quadrature.kernels.QuadratureProductBrownianLebesgueMeasure`
+
+    """
+
+    @property
+    def variance(self) -> float:
+        r"""The scale :math:`\sigma^2` of the kernel."""
+        raise NotImplementedError
+
+    def _dK_dx1_1d(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+        """Unscaled gradient of 1D Brownian kernel.
+
+        This method can be used in case the product Brownian is implemented via a List of
+        Brownian kernels.
+
+        :param x1: First argument of the kernel, shape = (n_points N,).
+        :param x2: Second argument of the kernel, shape = (n_points M,).
+        :return: The gradient of the kernel wrt x1 evaluated at (x1, x2), shape (N, M).
+        """
+        x1_rep = np.repeat(x1[:, 0][np.newaxis, ...], x2.shape[0], axis=0).T
+        x2_rep = np.repeat(x2[:, 0][np.newaxis, ...], x1.shape[0], axis=0)
+        return (x1_rep < x2_rep)[np.newaxis, :, :]
+
+    def dKdiag_dx(self, x: np.ndarray) -> np.ndarray:
+        return self.variance * np.ones((x.shape[1], x.shape[0]))

--- a/emukit/quadrature/interfaces/standard_kernels.py
+++ b/emukit/quadrature/interfaces/standard_kernels.py
@@ -87,8 +87,6 @@ class IRBF(IStandardKernel):
 class IProductMatern32(IStandardKernel):
     r"""Interface for a Matern32 product kernel.
 
-    Inherit from this class to wrap your ProductMatern32 kernel.
-
     The product kernel is of the form
     :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
 
@@ -149,8 +147,6 @@ class IProductMatern32(IStandardKernel):
 
 class IProductMatern52(IStandardKernel):
     r"""Interface for a Matern52 product kernel.
-
-    Inherit from this class to wrap your ProductMatern52 kernel.
 
     The product kernel is of the form
     :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
@@ -246,8 +242,6 @@ class IBrownian(IStandardKernel):
 class IProductBrownian(IStandardKernel):
     r"""Interface for a Brownian product kernel.
 
-    Inherit from this class to wrap your ProductBrownian kernel.
-
     The product kernel is of the form
     :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
 
@@ -284,9 +278,6 @@ class IProductBrownian(IStandardKernel):
         :param x2: Second argument of the kernel, shape = (n_points M,).
         :return: The gradient of the kernel wrt x1 evaluated at (x1, x2), shape (N, M).
         """
-        x1_rep = np.repeat(x1[:, 0][np.newaxis, ...], x2.shape[0], axis=0).T
-        x2_rep = np.repeat(x2[:, 0][np.newaxis, ...], x1.shape[0], axis=0)
-        return (x1_rep < x2_rep)[np.newaxis, :, :]
-
-    def dKdiag_dx(self, x: np.ndarray) -> np.ndarray:
-        return self.variance * np.ones((x.shape[1], x.shape[0]))
+        x1_rep = np.repeat(x1[np.newaxis, ...], x2.shape[0], axis=0).T
+        x2_rep = np.repeat(x2[np.newaxis, ...], x1.shape[0], axis=0)
+        return x1_rep < x2_rep

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -5,7 +5,12 @@
 
 
 from .quadrature_kernels import QuadratureKernel  # isort:skip
-from .quadrature_brownian import QuadratureBrownian, QuadratureBrownianLebesgueMeasure
+from .quadrature_brownian import (
+    QuadratureBrownian,
+    QuadratureBrownianLebesgueMeasure,
+    QuadratureProductBrownian,
+    QuadratureProductBrownianLebesgueMeasure,
+)
 from .quadrature_matern32 import QuadratureProductMatern32, QuadratureProductMatern32LebesgueMeasure
 from .quadrature_matern52 import QuadratureProductMatern52, QuadratureProductMatern52LebesgueMeasure
 from .quadrature_rbf import (
@@ -23,6 +28,8 @@ __all__ = [
     "QuadratureRBFLebesgueMeasure",
     "QuadratureRBFUniformMeasure",
     "QuadratureRBFIsoGaussMeasure",
+    "QuadratureProductBrownian",
+    "QuadratureProductBrownianLebesgueMeasure",
     "QuadratureProductMatern32",
     "QuadratureProductMatern32LebesgueMeasure",
     "QuadratureProductMatern52",

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -4,13 +4,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Optional, Union
+from typing import List, Optional, Tuple
 
 import numpy as np
 
-from ...quadrature.interfaces.standard_kernels import IBrownian
+from ...quadrature.interfaces.standard_kernels import IBrownian, IProductBrownian
 from ..kernels import QuadratureKernel
-from ..measures import BoxDomain, IntegrationMeasure
+from ..measures import IntegrationMeasure
 from ..typing import BoundsType
 
 
@@ -120,3 +120,135 @@ class QuadratureBrownianLebesgueMeasure(QuadratureBrownian):
     def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
         ub = self.integral_bounds.upper_bounds
         return self.variance * (ub - x2).T
+
+
+class QuadratureProductBrownian(QuadratureKernel):
+    r"""A product Brownian kernel augmented with integrability.
+
+    The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
+
+    .. math::
+        k_i(x, x') = \operatorname{min}(x_i, x_i')\quad\text{with}\quad x_i, x_i' \geq 0,
+
+    :math:`d` is the input dimensionality,
+    and :math:`\sigma^2` is the ``variance`` property.
+
+    .. note::
+        This class is compatible with the standard kernel :class:`IProductBrownian`.
+        Each subclass of this class implements an embedding w.r.t. a specific integration measure.
+
+    .. seealso::
+       * :class:`emukit.quadrature.interfaces.IProductBrownian`
+       * :class:`emukit.quadrature.kernels.QuadratureKernel`
+
+    :param brownian_kernel: The standard EmuKit product Brownian kernel.
+    :param integral_bounds: The integral bounds.
+                            List of D tuples, where D is the dimensionality
+                            of the integral and the tuples contain the lower and upper bounds of the integral
+                            i.e., [(lb_1, ub_1), (lb_2, ub_2), ..., (lb_D, ub_D)].
+                            ``None`` if bounds are infinite.
+    :param measure: The integration measure. ``None`` implies the standard Lebesgue measure.
+    :param variable_names: The (variable) name(s) of the integral.
+    """
+
+    def __init__(
+        self,
+        brownian_kernel: IProductBrownian,
+        integral_bounds: Optional[BoundsType],
+        measure: Optional[IntegrationMeasure],
+        variable_names: str = "",
+    ) -> None:
+        super().__init__(
+            kern=brownian_kernel, integral_bounds=integral_bounds, measure=measure, variable_names=variable_names
+        )
+
+    @property
+    def variance(self) -> float:
+        r"""The scale :math:`\sigma^2` of the kernel."""
+        return self.kern.variance
+
+    def qK(self, x2: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def Kq(self, x1: np.ndarray) -> np.ndarray:
+        return self.qK(x1).T
+
+    def qKq(self) -> float:
+        raise NotImplementedError
+
+    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
+        raise NotImplementedError
+
+    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
+        return self.dqK_dx(x1).T
+
+
+class QuadratureProductBrownianLebesgueMeasure(QuadratureProductBrownian):
+    """An product Brownian kernel augmented with integrability w.r.t. the standard Lebesgue measure.
+
+    .. seealso::
+       * :class:`emukit.quadrature.interfaces.IProductBrownian`
+       * :class:`emukit.quadrature.kernels.QuadratureProductBrownian`
+
+    :param brownian_kernel: The standard EmuKit product Brownian kernel.
+    :param integral_bounds: The integral bounds.
+                            List of D tuples, where D is the dimensionality
+                            of the integral and the tuples contain the lower and upper bounds of the integral
+                            i.e., [(lb_1, ub_1), (lb_2, ub_2), ..., (lb_D, ub_D)].
+                            ``None`` if bounds are infinite.
+    :param variable_names: The (variable) name(s) of the integral.
+
+    """
+
+    def __init__(
+        self, brownian_kernel: IProductBrownian, integral_bounds: BoundsType, variable_names: str = ""
+    ) -> None:
+        super().__init__(
+            brownian_kernel=brownian_kernel,
+            integral_bounds=integral_bounds,
+            measure=None,
+            variable_names=variable_names,
+        )
+
+    def qK(self, x2: np.ndarray, skip: List[int] = None) -> np.ndarray:
+        if skip is None:
+            skip = []
+
+        qK = np.ones(x2.shape[0])
+        for dim in range(x2.shape[1]):
+            if dim in skip:
+                continue
+            qK *= self._qK_1d(x=x2[:, dim], domain=self.integral_bounds.bounds[dim])
+        return qK[None, :] * self.variance
+
+    def qKq(self) -> float:
+        qKq = 1.0
+        for dim in range(self.input_dim):
+            qKq *= self._qKq_1d(domain=self.integral_bounds.bounds[dim])
+        return self.variance * qKq
+
+    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
+        input_dim = x2.shape[1]
+        dqK_dx = np.zeros([input_dim, x2.shape[0]])
+        for dim in range(input_dim):
+            grad_term = self._dqK_dx_1d(x=x2[:, dim], domain=self.integral_bounds.bounds[dim])
+            dqK_dx[dim, :] = grad_term * self.qK(x2, skip=[dim])[0, :]
+        return dqK_dx
+
+    # one dimensional integrals start here
+    def _qK_1d(self, x: np.ndarray, domain: Tuple[float, float]) -> np.ndarray:
+        """Unscaled kernel mean for 1D Brownian kernel."""
+        (a, b) = domain
+        kernel_mean = b * x - 0.5 * x**2 - 0.5 * a**2
+        return kernel_mean.T
+
+    def _qKq_1d(self, domain: Tuple[float, float]) -> float:
+        """Unscaled kernel variance for 1D Brownian kernel."""
+        a, b = domain
+        qKq = 0.5 * b * (b**2 - a**2) - (b**3 - a**3) / 6 - 0.5 * a**2 * (b - a)
+        return float(qKq)
+
+    def _dqK_dx_1d(self, x, domain):
+        """Unscaled gradient of 1D Brownian kernel mean."""
+        _, b = domain
+        return (b - x).T

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -11,6 +11,7 @@ from test_quadrature_kernels import (
     get_qbrownian_lebesque,
     get_qmatern32_lebesque,
     get_qmatern52_lebesque,
+    get_qprodbrownian_lebesque,
     get_qrbf_gauss_iso,
     get_qrbf_lebesque,
     get_qrbf_uniform_finite,
@@ -118,8 +119,9 @@ if __name__ == "__main__":
     # === Choose KERNEL BELOW ======
     # KERNEL = 'rbf'
     # KERNEL = "matern32"
-    KERNEL = "matern52"
+    # KERNEL = "matern52"
     # KERNEL = "brownian"
+    KERNEL = "prodbrownian"
     # === CHOOSE KERNEL ABOVE ======
 
     _e = "Kernel embedding not implemented."
@@ -143,6 +145,9 @@ if __name__ == "__main__":
     elif KERNEL == "brownian":
         if MEASURE_INTBOUNDS == "Lebesgue-finite":
             emukit_qkern, dat = get_qbrownian_lebesque()
+    elif KERNEL == "prodbrownian":
+        if MEASURE_INTBOUNDS == "Lebesgue-finite":
+            emukit_qkern, dat = get_qprodbrownian_lebesque()
         else:
             raise ValueError(_e)
 

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -9,11 +9,18 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from utils import check_grad, sample_uniform
 
-from emukit.model_wrappers.gpy_quadrature_wrappers import BrownianGPy, ProductMatern32GPy, ProductMatern52GPy, RBFGPy
+from emukit.model_wrappers.gpy_quadrature_wrappers import (
+    BrownianGPy,
+    ProductBrownianGPy,
+    ProductMatern32GPy,
+    ProductMatern52GPy,
+    RBFGPy,
+)
 from emukit.quadrature.interfaces import IStandardKernel
 from emukit.quadrature.kernels import (
     QuadratureBrownianLebesgueMeasure,
     QuadratureKernel,
+    QuadratureProductBrownianLebesgueMeasure,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureProductMatern52LebesgueMeasure,
     QuadratureRBFIsoGaussMeasure,
@@ -43,6 +50,18 @@ class DataLebesqueSDElike:
     # x1 and x2 must lay inside domain
     x1 = np.array([[0.3], [0.8], [1.5]])
     x2 = np.array([[0.25], [0.5], [1.0], [1.2]])
+    N = 3
+    M = 4
+    dat_bounds = integral_bounds
+
+
+@dataclass
+class DataPositiveDomain:
+    D = 2
+    integral_bounds = [(0.1, 2), (0.2, 3)]
+    # x1 and x2 must lay inside domain
+    x1 = np.array([[0.3, 1], [0.8, 0.5], [1.5, 2.8]])
+    x2 = np.array([[0.25, 1.1], [0.5, 0.3], [1.0, 1.3], [1.2, 1.2]])
     N = 3
     M = 4
     dat_bounds = integral_bounds
@@ -113,6 +132,12 @@ class EmukitBrownian:
     kern = BrownianGPy(GPy.kern.Brownian(input_dim=1, variance=var))
 
 
+@dataclass
+class EmukitProductBrownian:
+    variance = 0.7
+    kern = ProductBrownianGPy(variance=variance, input_dim=2)
+
+
 def get_qrbf_lebesque():
     dat = DataLebesque()
     qkern = QuadratureRBFLebesgueMeasure(EmukitRBF().kern, integral_bounds=dat.integral_bounds)
@@ -155,6 +180,12 @@ def get_qmatern52_lebesque():
 def get_qbrownian_lebesque():
     dat = DataLebesqueSDElike()
     qkern = QuadratureBrownianLebesgueMeasure(EmukitBrownian().kern, integral_bounds=dat.integral_bounds)
+    return qkern, dat
+
+
+def get_qprodbrownian_lebesque():
+    dat = DataPositiveDomain()
+    qkern = QuadratureProductBrownianLebesgueMeasure(EmukitProductBrownian().kern, integral_bounds=dat.integral_bounds)
     return qkern, dat
 
 
@@ -201,6 +232,12 @@ def qbrownian_lebesgue():
     return qkern, dat.x1, dat.x2, dat.N, dat.M, dat.D, dat.dat_bounds
 
 
+@pytest.fixture
+def qprodbrownian_lebesque():
+    qkern, dat = get_qprodbrownian_lebesque()
+    return qkern, dat.x1, dat.x2, dat.N, dat.M, dat.D, dat.dat_bounds
+
+
 embeddings_test_list = [
     lazy_fixture("qrbf_lebesgue"),
     lazy_fixture("qrbf_gauss_iso"),
@@ -209,6 +246,7 @@ embeddings_test_list = [
     lazy_fixture("qmatern32_lebesgue"),
     lazy_fixture("qmatern52_lebesgue"),
     lazy_fixture("qbrownian_lebesgue"),
+    lazy_fixture("qprodbrownian_lebesque"),
 ]
 
 
@@ -239,6 +277,7 @@ def test_qkernel_shapes(kernel_embedding):
         (embeddings_test_list[4], [33.6816570527734, 33.726646173769595]),
         (embeddings_test_list[5], [36.311780552275614, 36.36134818184079]),
         (embeddings_test_list[6], [0.6528048146871609, 0.653858667201299]),
+        (embeddings_test_list[7], [16.435165116047134, 16.495812322522422]),
     ],
 )
 def test_qkernel_qKq(kernel_embedding, interval):
@@ -332,6 +371,17 @@ def test_qkernel_qKq(kernel_embedding, interval):
                 ]
             ),
         ),
+        (
+            embeddings_test_list[7],
+            np.array(
+                [
+                    [0.8676427638843673, 0.8690939535336577],
+                    [0.5081408814743865, 0.5088751098284771],
+                    [3.17133629344498, 3.1805415930787873],
+                    [3.3478871560376082, 3.3584198980953057],
+                ]
+            ),
+        ),
     ],
 )
 def test_qkernel_qK(kernel_embedding, intervals):
@@ -378,7 +428,7 @@ def test_qkernel_gradient_values(kernel_embedding):
     # dKdiag_dx
     in_shape = x1.shape
     func = lambda x: np.diag(emukit_qkernel.K(x, x))
-    dfunc = lambda x: emukit_qkernel.dKdiag_dx(x1)
+    dfunc = lambda x: emukit_qkernel.dKdiag_dx(x)
     check_grad(func, dfunc, in_shape, dat_bounds)
 
     # dK_dx1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds

- kernel embeddings for the Brownian product kernel w.r.t. Lebesgue measure.
- an EmuKit interface for this kernel.
- a GPy wrapper for said interface.
- the kernel is added to the tests (shape, value, gradient etc tests) by adding a fixture to the existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
