### PR TITLE
`QuadratureProductKernel` base class

### DIFF
--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from .quadrature_kernels import QuadratureKernel  # isort:skip
+from .quadrature_kernels import QuadratureKernel, QuadratureProductKernel  # isort:skip
 from .quadrature_brownian import (
     QuadratureBrownian,
     QuadratureBrownianLebesgueMeasure,
@@ -28,6 +28,7 @@ __all__ = [
     "QuadratureRBFLebesgueMeasure",
     "QuadratureRBFUniformMeasure",
     "QuadratureRBFIsoGaussMeasure",
+    "QuadratureProductKernel",
     "QuadratureProductBrownian",
     "QuadratureProductBrownianLebesgueMeasure",
     "QuadratureProductMatern32",

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -15,7 +15,7 @@ from ..typing import BoundsType
 
 
 class QuadratureBrownian(QuadratureKernel):
-    r"""A Brownian motion kernel augmented with integrability.
+    r"""Base class for a Brownian motion kernel augmented with integrability.
 
     .. math::
         k(x, x') = \sigma^2 \operatorname{min}(x, x')\quad\text{with}\quad x, x' \geq 0,
@@ -115,7 +115,7 @@ class QuadratureBrownianLebesgueMeasure(QuadratureBrownian):
 
 
 class QuadratureProductBrownian(QuadratureProductKernel):
-    r"""A product Brownian kernel augmented with integrability.
+    r"""Base class for a product Brownian kernel augmented with integrability.
 
     The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
 

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import List, Optional, Tuple
+from typing import Optional, Union
 
 import numpy as np
 
 from ...quadrature.interfaces.standard_kernels import IBrownian, IProductBrownian
-from ..kernels import QuadratureKernel
+from ..kernels import QuadratureKernel, QuadratureProductKernel
 from ..measures import IntegrationMeasure
 from ..typing import BoundsType
 
@@ -74,17 +74,11 @@ class QuadratureBrownian(QuadratureKernel):
     def qK(self, x2: np.ndarray) -> np.ndarray:
         raise NotImplementedError
 
-    def Kq(self, x1: np.ndarray) -> np.ndarray:
-        return self.qK(x1).T
-
     def qKq(self) -> float:
         raise NotImplementedError
 
     def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
         raise NotImplementedError
-
-    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
-        return self.dqK_dx(x1).T
 
 
 class QuadratureBrownianLebesgueMeasure(QuadratureBrownian):
@@ -129,7 +123,7 @@ class QuadratureBrownianLebesgueMeasure(QuadratureBrownian):
         return self.variance * (ub - x2).T
 
 
-class QuadratureProductBrownian(QuadratureKernel):
+class QuadratureProductBrownian(QuadratureProductKernel):
     r"""A product Brownian kernel augmented with integrability.
 
     The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
@@ -147,7 +141,7 @@ class QuadratureProductBrownian(QuadratureKernel):
 
     .. seealso::
        * :class:`emukit.quadrature.interfaces.IProductBrownian`
-       * :class:`emukit.quadrature.kernels.QuadratureKernel`
+       * :class:`emukit.quadrature.kernels.QuadratureProductKernel`
 
     :param brownian_kernel: The standard EmuKit product Brownian kernel.
     :param integral_bounds: The integral bounds.
@@ -187,21 +181,6 @@ class QuadratureProductBrownian(QuadratureKernel):
         r"""The offset :math:`c` of the kernel."""
         return self.kern.offset
 
-    def qK(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def Kq(self, x1: np.ndarray) -> np.ndarray:
-        return self.qK(x1).T
-
-    def qKq(self) -> float:
-        raise NotImplementedError
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
-        return self.dqK_dx(x1).T
-
 
 class QuadratureProductBrownianLebesgueMeasure(QuadratureProductBrownian):
     """An product Brownian kernel augmented with integrability w.r.t. the standard Lebesgue measure.
@@ -230,45 +209,24 @@ class QuadratureProductBrownianLebesgueMeasure(QuadratureProductBrownian):
             variable_names=variable_names,
         )
 
-    def qK(self, x2: np.ndarray, skip: List[int] = None) -> np.ndarray:
-        if skip is None:
-            skip = []
+    def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.variance * z
 
-        qK = np.ones(x2.shape[0])
-        for dim in range(x2.shape[1]):
-            if dim in skip:
-                continue
-            qK *= self._qK_1d(x=x2[:, dim], domain=self.integral_bounds.bounds[dim])
-        return qK[None, :] * self.variance
+    def _get_univariate_kwargs(self, dim: int) -> dict:
+        return {"domain": self.integral_bounds.bounds[dim], "offset": self.offset}
 
-    def qKq(self) -> float:
-        qKq = 1.0
-        for dim in range(self.input_dim):
-            qKq *= self._qKq_1d(domain=self.integral_bounds.bounds[dim])
-        return self.variance * qKq
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        input_dim = x2.shape[1]
-        dqK_dx = np.zeros([input_dim, x2.shape[0]])
-        for dim in range(input_dim):
-            grad_term = self._dqK_dx_1d(x=x2[:, dim], domain=self.integral_bounds.bounds[dim])
-            dqK_dx[dim, :] = grad_term * self.qK(x2, skip=[dim])[0, :]
-        return dqK_dx
-
-    # one dimensional integrals start here
-    def _qK_1d(self, x: np.ndarray, domain: Tuple[float, float]) -> np.ndarray:
-        """Unscaled kernel mean for 1D Brownian kernel."""
-        (a, b) = domain
+    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        a, b = kwargs["domain"]
+        offset = kwargs["offset"]
         kernel_mean = b * x - 0.5 * x**2 - 0.5 * a**2
-        return kernel_mean.T - self.offset * (b - a)
+        return kernel_mean.T - offset * (b - a)
 
-    def _qKq_1d(self, domain: Tuple[float, float]) -> float:
-        """Unscaled kernel variance for 1D Brownian kernel."""
-        a, b = domain
+    def _qKq_1d(self, **kwargs) -> float:
+        a, b = kwargs["domain"]
+        offset = kwargs["offset"]
         qKq = 0.5 * b * (b**2 - a**2) - (b**3 - a**3) / 6 - 0.5 * a**2 * (b - a)
-        return float(qKq) - self.offset * (b - a) ** 2
+        return float(qKq) - offset * (b - a) ** 2
 
-    def _dqK_dx_1d(self, x, domain):
-        """Unscaled gradient of 1D Brownian kernel mean."""
-        _, b = domain
+    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        _, b = kwargs["domain"]
         return (b - x).T

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -71,15 +71,6 @@ class QuadratureBrownian(QuadratureKernel):
         r"""The scale :math:`\sigma^2` of the kernel."""
         return self.kern.variance
 
-    def qK(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def qKq(self) -> float:
-        raise NotImplementedError
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
 
 class QuadratureBrownianLebesgueMeasure(QuadratureBrownian):
     """A Brownian motion kernel augmented with integrability w.r.t. the standard Lebesgue measure.

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -212,21 +212,21 @@ class QuadratureProductBrownianLebesgueMeasure(QuadratureProductBrownian):
     def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         return self.variance * z
 
-    def _get_univariate_kwargs(self, dim: int) -> dict:
+    def _get_univariate_parameters(self, dim: int) -> dict:
         return {"domain": self.integral_bounds.bounds[dim], "offset": self.offset}
 
-    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        a, b = kwargs["domain"]
-        offset = kwargs["offset"]
+    def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        a, b = parameters["domain"]
+        offset = parameters["offset"]
         kernel_mean = b * x - 0.5 * x**2 - 0.5 * a**2
         return kernel_mean.T - offset * (b - a)
 
-    def _qKq_1d(self, **kwargs) -> float:
-        a, b = kwargs["domain"]
-        offset = kwargs["offset"]
+    def _qKq_1d(self, **parameters) -> float:
+        a, b = parameters["domain"]
+        offset = parameters["offset"]
         qKq = 0.5 * b * (b**2 - a**2) - (b**3 - a**3) / 6 - 0.5 * a**2 * (b - a)
         return float(qKq) - offset * (b - a) ** 2
 
-    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        _, b = kwargs["domain"]
+    def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        _, b = parameters["domain"]
         return (b - x).T

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Optional
+from typing import List, Optional, Union
 
 import numpy as np
 
@@ -86,7 +86,7 @@ class QuadratureKernel:
         :param x1: The locations where the kernel mean is evaluated, shape (n_points, input_dim).
         :returns: The kernel mean at x1, shape (n_points, 1).
         """
-        raise NotImplementedError
+        return self.qK(x1).T
 
     def qKq(self) -> np.float:
         """The kernel integrated over both arguments x1 and x2.
@@ -139,4 +139,77 @@ class QuadratureKernel:
         :param x1: The locations where the gradient is evaluated, shape (n_points N, N, input_dim).
         :return: The gradient with shape (N, input_dim).
         """
+        return self.dqK_dx(x1).T
+
+
+class QuadratureProductKernel(QuadratureKernel):
+    """Abstract class for a product kernel augmented with integrability.
+
+    The product kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')`
+    where :math:`k_i(x, x')` is a univariate kernel acting on dimension :math:`i`.
+
+    :param kern: Standard EmuKit kernel (must be a product kernel).
+    :param integral_bounds: The integral bounds.
+                            List of D tuples, where D is the dimensionality
+                            of the integral and the tuples contain the lower and upper bounds of the integral
+                            i.e., [(lb_1, ub_1), (lb_2, ub_2), ..., (lb_D, ub_D)].
+                            ``None`` if bounds are infinite.
+    :param measure: The integration measure. ``None`` implies the standard Lebesgue measure.
+    :param variable_names: The (variable) name(s) of the integral
+
+    """
+
+    def __init__(
+        self,
+        kern: IStandardKernel,
+        integral_bounds: Optional[BoundsType],
+        measure: Optional[IntegrationMeasure],
+        variable_names: str = "",
+    ) -> None:
+
+        super().__init__(kern=kern, integral_bounds=integral_bounds, measure=measure, variable_names=variable_names)
+
+    def qK(self, x2: np.ndarray, skip: List[int] = None) -> np.ndarray:
+        if skip is None:
+            skip = []
+
+        qK = np.ones(x2.shape[0])
+        for dim in range(x2.shape[1]):
+            if dim in skip:
+                continue
+            qK *= self._qK_1d(x2[:, dim], **self._get_univariate_kwargs(dim))
+        return self._scale(qK[None, :])
+
+    def qKq(self) -> float:
+        qKq = 1.0
+        for dim in range(self.input_dim):
+            qKq *= self._qKq_1d(**self._get_univariate_kwargs(dim))
+        return self._scale(qKq)
+
+    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
+        input_dim = x2.shape[1]
+        dqK_dx = np.zeros([input_dim, x2.shape[0]])
+        for dim in range(input_dim):
+            grad_term = self._dqK_dx_1d(x2[:, dim], **self._get_univariate_kwargs(dim))
+            dqK_dx[dim, :] = grad_term * self.qK(x2, skip=[dim])[0, :]
+        return dqK_dx
+
+    def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        """Scales the input ``z`` with a scalar value, for example the variance of the kernel."""
+        raise NotImplementedError
+
+    def _get_univariate_kwargs(self, dim: int) -> dict:
+        """Keywords arguments used my the methods related to the univariate kernel of dimension ``dim``."""
+        raise NotImplementedError
+
+    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        """Unscaled kernel mean for univariate version of kernel kernel."""
+        raise NotImplementedError
+
+    def _qKq_1d(self, **kwargs) -> float:
+        """Unscaled kernel variance for univariate version of kernel."""
+        raise NotImplementedError
+
+    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        """Unscaled gradient of univariate version of kernel mean."""
         raise NotImplementedError

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -197,7 +197,7 @@ class QuadratureProductKernel(QuadratureKernel):
     def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         """Scales the input ``z`` with a scalar value specific to the kernel.
 
-        :param z: The value to be scales.
+        :param z: The value to be scaled.
         :return: The scaled value.
         """
         raise NotImplementedError
@@ -211,20 +211,21 @@ class QuadratureProductKernel(QuadratureKernel):
         """
         raise NotImplementedError
 
+    # methods related to the univariate version of the kernel
     def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         """Unscaled kernel mean for univariate version of kernel.
 
         :param x: The locations where the kernel mean is evaluated, shape (n_points, ).
         :param parameters: The parameters of the univariate kernel.
-        :return: The kernel mean of the univariate kernel evaluated at a, shape (n_points, ).
+        :return: The kernel mean of the univariate kernel evaluated at x, shape (n_points, ).
         """
         raise NotImplementedError
 
     def _qKq_1d(self, **parameters) -> float:
-        """Unscaled kernel variance for univariate version of kernel.
+        """Unscaled kernel integrated over both arguments for univariate version of kernel.
 
         :param parameters: The parameters of the univariate kernel.
-        :return:
+        :returns: Double integrated univariate kernel.
         """
         raise NotImplementedError
 
@@ -233,6 +234,6 @@ class QuadratureProductKernel(QuadratureKernel):
 
         :param x: The locations where the kernel mean is evaluated, shape (n_points, ).
         :param parameters: The parameters of the univariate kernel.
-        :return:
+        :return: The gradient with shape (n_points, ).
         """
         raise NotImplementedError

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -177,39 +177,62 @@ class QuadratureProductKernel(QuadratureKernel):
         for dim in range(x2.shape[1]):
             if dim in skip:
                 continue
-            qK *= self._qK_1d(x2[:, dim], **self._get_univariate_kwargs(dim))
+            qK *= self._qK_1d(x2[:, dim], **self._get_univariate_parameters(dim))
         return self._scale(qK[None, :])
 
     def qKq(self) -> float:
         qKq = 1.0
         for dim in range(self.input_dim):
-            qKq *= self._qKq_1d(**self._get_univariate_kwargs(dim))
+            qKq *= self._qKq_1d(**self._get_univariate_parameters(dim))
         return self._scale(qKq)
 
     def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
         input_dim = x2.shape[1]
         dqK_dx = np.zeros([input_dim, x2.shape[0]])
         for dim in range(input_dim):
-            grad_term = self._dqK_dx_1d(x2[:, dim], **self._get_univariate_kwargs(dim))
+            grad_term = self._dqK_dx_1d(x2[:, dim], **self._get_univariate_parameters(dim))
             dqK_dx[dim, :] = grad_term * self.qK(x2, skip=[dim])[0, :]
         return dqK_dx
 
     def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
-        """Scales the input ``z`` with a scalar value, for example the variance of the kernel."""
+        """Scales the input ``z`` with a scalar value specific to the kernel.
+
+        :param z: The value to be scales.
+        :return: The scaled value.
+        """
         raise NotImplementedError
 
-    def _get_univariate_kwargs(self, dim: int) -> dict:
-        """Keywords arguments used my the methods related to the univariate kernel of dimension ``dim``."""
+    def _get_univariate_parameters(self, dim: int) -> dict:
+        """Keywords arguments used by methods related to the univariate, unscaled version
+         of the kernel of dimension ``dim``.
+
+        :param dim: The dimension.
+        :return: The parameters of dimension ``dim``.
+        """
         raise NotImplementedError
 
-    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        """Unscaled kernel mean for univariate version of kernel kernel."""
+    def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        """Unscaled kernel mean for univariate version of kernel.
+
+        :param x: The locations where the kernel mean is evaluated, shape (n_points, ).
+        :param parameters: The parameters of the univariate kernel.
+        :return: The kernel mean of the univariate kernel evaluated at a, shape (n_points, ).
+        """
         raise NotImplementedError
 
-    def _qKq_1d(self, **kwargs) -> float:
-        """Unscaled kernel variance for univariate version of kernel."""
+    def _qKq_1d(self, **parameters) -> float:
+        """Unscaled kernel variance for univariate version of kernel.
+
+        :param parameters: The parameters of the univariate kernel.
+        :return:
+        """
         raise NotImplementedError
 
-    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        """Unscaled gradient of univariate version of kernel mean."""
+    def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        """Unscaled gradient of univariate version of the kernel mean.
+
+        :param x: The locations where the kernel mean is evaluated, shape (n_points, ).
+        :param parameters: The parameters of the univariate kernel.
+        :return:
+        """
         raise NotImplementedError

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -1,16 +1,16 @@
 """The product Matern32 kernel embeddings."""
 
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 
 from ...quadrature.interfaces.standard_kernels import IProductMatern32
 from ..measures import IntegrationMeasure
 from ..typing import BoundsType
-from .quadrature_kernels import QuadratureKernel
+from .quadrature_kernels import QuadratureProductKernel
 
 
-class QuadratureProductMatern32(QuadratureKernel):
+class QuadratureProductMatern32(QuadratureProductKernel):
     r"""A product Matern32 kernel augmented with integrability.
 
     The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
@@ -28,7 +28,7 @@ class QuadratureProductMatern32(QuadratureKernel):
 
     .. seealso::
        * :class:`emukit.quadrature.interfaces.IProductMatern32`
-       * :class:`emukit.quadrature.kernels.QuadratureKernel`
+       * :class:`emukit.quadrature.kernels.QuadratureProductKernel`
 
     :param matern_kernel: The standard EmuKit product Matern32 kernel.
     :param integral_bounds: The integral bounds.
@@ -67,21 +67,6 @@ class QuadratureProductMatern32(QuadratureKernel):
         r"""The scale :math:`\sigma^2` of the kernel."""
         return self.kern.variance
 
-    def qK(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def Kq(self, x1: np.ndarray) -> np.ndarray:
-        return self.qK(x1).T
-
-    def qKq(self) -> float:
-        raise NotImplementedError
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
-        return self.dqK_dx(x1).T
-
 
 class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32):
     """An product Matern32 kernel augmented with integrability w.r.t. the standard Lebesgue measure.
@@ -105,37 +90,15 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32):
             matern_kernel=matern_kernel, integral_bounds=integral_bounds, measure=None, variable_names=variable_names
         )
 
-    def qK(self, x2: np.ndarray, skip: List[int] = None) -> np.ndarray:
-        if skip is None:
-            skip = []
+    def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.variance * z
 
-        qK = np.ones(x2.shape[0])
-        for dim in range(x2.shape[1]):
-            if dim in skip:
-                continue
-            qK *= self._qK_1d(x=x2[:, dim], domain=self.integral_bounds.bounds[dim], ell=self.lengthscales[dim])
-        return qK[None, :] * self.variance
+    def _get_univariate_kwargs(self, dim: int) -> dict:
+        return {"domain": self.integral_bounds.bounds[dim], "ell": self.lengthscales[dim]}
 
-    def qKq(self) -> float:
-        qKq = 1.0
-        for dim in range(self.input_dim):
-            qKq *= self._qKq_1d(domain=self.integral_bounds.bounds[dim], ell=self.lengthscales[dim])
-        return self.variance * qKq
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        input_dim = x2.shape[1]
-        dqK_dx = np.zeros([input_dim, x2.shape[0]])
-        for dim in range(input_dim):
-            grad_term = self._dqK_dx_1d(
-                x=x2[:, dim], domain=self.integral_bounds.bounds[dim], ell=self.lengthscales[dim]
-            )
-            dqK_dx[dim, :] = grad_term * self.qK(x2, skip=[dim])[0, :]
-        return dqK_dx
-
-    # one dimensional integrals start here
-    def _qK_1d(self, x: np.ndarray, domain: Tuple[float, float], ell: float) -> np.ndarray:
-        """Unscaled kernel mean for 1D Matern32 kernel."""
-        (a, b) = domain
+    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        a, b = kwargs["domain"]
+        ell = kwargs["ell"]
         s3 = np.sqrt(3.0)
         first_term = 4.0 * ell / s3
         second_term = -np.exp(s3 * (x - b) / ell) * (b + 2.0 * ell / s3 - x)
@@ -143,17 +106,16 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32):
         return first_term + second_term + third_term
 
     def _qKq_1d(self, domain: Tuple[float, float], ell: float) -> float:
-        """Unscaled kernel variance for 1D Matern32 kernel."""
         a, b = domain
         r = b - a
         c = np.sqrt(3.0) * r
         qKq = 2.0 * ell / 3.0 * (2.0 * c - 3.0 * ell + np.exp(-c / ell) * (c + 3.0 * ell))
         return float(qKq)
 
-    def _dqK_dx_1d(self, x, domain, ell):
-        """Unscaled gradient of 1D Matern32 kernel mean."""
+    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        a, b = kwargs["domain"]
+        ell = kwargs["ell"]
         s3 = np.sqrt(3)
-        a, b = domain
         exp_term_b = np.exp(s3 * (x - b) / ell)
         exp_term_a = np.exp(s3 * (a - x) / ell)
         first_term = exp_term_b * (-1 + (s3 / ell) * (x - b))

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -11,7 +11,7 @@ from .quadrature_kernels import QuadratureProductKernel
 
 
 class QuadratureProductMatern32(QuadratureProductKernel):
-    r"""A product Matern32 kernel augmented with integrability.
+    r"""Base class for a product Matern32 kernel augmented with integrability.
 
     The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
 

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -93,28 +93,29 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32):
     def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         return self.variance * z
 
-    def _get_univariate_kwargs(self, dim: int) -> dict:
+    def _get_univariate_parameters(self, dim: int) -> dict:
         return {"domain": self.integral_bounds.bounds[dim], "ell": self.lengthscales[dim]}
 
-    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        a, b = kwargs["domain"]
-        ell = kwargs["ell"]
+    def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        a, b = parameters["domain"]
+        ell = parameters["ell"]
         s3 = np.sqrt(3.0)
         first_term = 4.0 * ell / s3
         second_term = -np.exp(s3 * (x - b) / ell) * (b + 2.0 * ell / s3 - x)
         third_term = -np.exp(s3 * (a - x) / ell) * (x + 2.0 * ell / s3 - a)
         return first_term + second_term + third_term
 
-    def _qKq_1d(self, domain: Tuple[float, float], ell: float) -> float:
-        a, b = domain
+    def _qKq_1d(self, **parameters) -> float:
+        a, b = parameters["domain"]
+        ell = parameters["ell"]
         r = b - a
         c = np.sqrt(3.0) * r
         qKq = 2.0 * ell / 3.0 * (2.0 * c - 3.0 * ell + np.exp(-c / ell) * (c + 3.0 * ell))
         return float(qKq)
 
-    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        a, b = kwargs["domain"]
-        ell = kwargs["ell"]
+    def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        a, b = parameters["domain"]
+        ell = parameters["ell"]
         s3 = np.sqrt(3)
         exp_term_b = np.exp(s3 * (x - b) / ell)
         exp_term_a = np.exp(s3 * (a - x) / ell)

--- a/emukit/quadrature/kernels/quadrature_matern52.py
+++ b/emukit/quadrature/kernels/quadrature_matern52.py
@@ -11,7 +11,7 @@ from .quadrature_kernels import QuadratureProductKernel
 
 
 class QuadratureProductMatern52(QuadratureProductKernel):
-    r"""A product Matern52 kernel augmented with integrability.
+    r"""Base class for a product Matern52 kernel augmented with integrability.
 
     The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
 

--- a/emukit/quadrature/kernels/quadrature_matern52.py
+++ b/emukit/quadrature/kernels/quadrature_matern52.py
@@ -93,12 +93,12 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52):
     def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
         return self.variance * z
 
-    def _get_univariate_kwargs(self, dim: int) -> dict:
+    def _get_univariate_parameters(self, dim: int) -> dict:
         return {"domain": self.integral_bounds.bounds[dim], "ell": self.lengthscales[dim]}
 
-    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        a, b = kwargs["domain"]
-        ell = kwargs["ell"]
+    def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        a, b = parameters["domain"]
+        ell = parameters["ell"]
         s5 = np.sqrt(5)
         first_term = 16 * ell / (3 * s5)
         second_term = (
@@ -109,17 +109,17 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52):
         )
         return first_term + second_term + third_term
 
-    def _qKq_1d(self, **kwargs) -> float:
-        a, b = kwargs["domain"]
-        ell = kwargs["ell"]
+    def _qKq_1d(self, **parameters) -> float:
+        a, b = parameters["domain"]
+        ell = parameters["ell"]
         c = np.sqrt(5) * (b - a)
         bracket_term = 5 * a**2 - 10 * a * b + 5 * b**2 + 7 * c * ell + 15 * ell**2
         qKq = (2 * ell * (8 * c - 15 * ell) + 2 * np.exp(-c / ell) * bracket_term) / 15
         return float(qKq)
 
-    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
-        a, b = kwargs["domain"]
-        ell = kwargs["ell"]
+    def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
+        a, b = parameters["domain"]
+        ell = parameters["ell"]
         s5 = np.sqrt(5)
         first_exp = -np.exp(s5 * (x - b) / ell) / (15 * ell)
         first_term = first_exp * (15 * ell - 15 * s5 * (x - b) + 25 / ell * (x - b) ** 2)

--- a/emukit/quadrature/kernels/quadrature_matern52.py
+++ b/emukit/quadrature/kernels/quadrature_matern52.py
@@ -1,16 +1,16 @@
 """The product Matern52 kernel embeddings."""
 
-from typing import List, Optional, Tuple
+from typing import Optional, Union
 
 import numpy as np
 
 from ...quadrature.interfaces.standard_kernels import IProductMatern52
 from ..measures import IntegrationMeasure
 from ..typing import BoundsType
-from .quadrature_kernels import QuadratureKernel
+from .quadrature_kernels import QuadratureProductKernel
 
 
-class QuadratureProductMatern52(QuadratureKernel):
+class QuadratureProductMatern52(QuadratureProductKernel):
     r"""A product Matern52 kernel augmented with integrability.
 
     The kernel is of the form :math:`k(x, x') = \sigma^2 \prod_{i=1}^d k_i(x, x')` where
@@ -28,7 +28,7 @@ class QuadratureProductMatern52(QuadratureKernel):
 
     .. seealso::
        * :class:`emukit.quadrature.interfaces.IProductMatern52`
-       * :class:`emukit.quadrature.kernels.QuadratureKernel`
+       * :class:`emukit.quadrature.kernels.QuadratureProductKernel`
 
     :param matern_kernel: The standard EmuKit product Matern52 kernel.
     :param integral_bounds: The integral bounds.
@@ -67,21 +67,6 @@ class QuadratureProductMatern52(QuadratureKernel):
         r"""The scale :math:`\sigma^2` of the kernel."""
         return self.kern.variance
 
-    def qK(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def Kq(self, x1: np.ndarray) -> np.ndarray:
-        return self.qK(x1).T
-
-    def qKq(self) -> float:
-        raise NotImplementedError
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
-        return self.dqK_dx(x1).T
-
 
 class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52):
     """An product Matern52 kernel augmented with integrability w.r.t. the standard Lebesgue measure.
@@ -105,37 +90,15 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52):
             matern_kernel=matern_kernel, integral_bounds=integral_bounds, measure=None, variable_names=variable_names
         )
 
-    def qK(self, x2: np.ndarray, skip: List[int] = None) -> np.ndarray:
-        if skip is None:
-            skip = []
+    def _scale(self, z: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
+        return self.variance * z
 
-        qK = np.ones(x2.shape[0])
-        for dim in range(x2.shape[1]):
-            if dim in skip:
-                continue
-            qK *= self._qK_1d(x=x2[:, dim], domain=self.integral_bounds.bounds[dim], ell=self.lengthscales[dim])
-        return qK[None, :] * self.variance
+    def _get_univariate_kwargs(self, dim: int) -> dict:
+        return {"domain": self.integral_bounds.bounds[dim], "ell": self.lengthscales[dim]}
 
-    def qKq(self) -> float:
-        qKq = 1.0
-        for dim in range(self.input_dim):
-            qKq *= self._qKq_1d(domain=self.integral_bounds.bounds[dim], ell=self.lengthscales[dim])
-        return self.variance * qKq
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        input_dim = x2.shape[1]
-        dqK_dx = np.zeros([input_dim, x2.shape[0]])
-        for dim in range(input_dim):
-            grad_term = self._dqK_dx_1d(
-                x=x2[:, dim], domain=self.integral_bounds.bounds[dim], ell=self.lengthscales[dim]
-            )
-            dqK_dx[dim, :] = grad_term * self.qK(x2, skip=[dim])[0, :]
-        return dqK_dx
-
-    # one dimensional integrals start here
-    def _qK_1d(self, x: np.ndarray, domain: Tuple[float, float], ell: float) -> np.ndarray:
-        """Unscaled kernel mean for 1D Matern52 kernel."""
-        (a, b) = domain
+    def _qK_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        a, b = kwargs["domain"]
+        ell = kwargs["ell"]
         s5 = np.sqrt(5)
         first_term = 16 * ell / (3 * s5)
         second_term = (
@@ -146,17 +109,17 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52):
         )
         return first_term + second_term + third_term
 
-    def _qKq_1d(self, domain: Tuple[float, float], ell: float) -> float:
-        """Unscaled kernel variance for 1D Matern52 kernel."""
-        a, b = domain
+    def _qKq_1d(self, **kwargs) -> float:
+        a, b = kwargs["domain"]
+        ell = kwargs["ell"]
         c = np.sqrt(5) * (b - a)
         bracket_term = 5 * a**2 - 10 * a * b + 5 * b**2 + 7 * c * ell + 15 * ell**2
         qKq = (2 * ell * (8 * c - 15 * ell) + 2 * np.exp(-c / ell) * bracket_term) / 15
         return float(qKq)
 
-    def _dqK_dx_1d(self, x, domain, ell) -> np.ndarray:
-        """Unscaled gradient of 1D Matern52 kernel mean."""
-        a, b = domain
+    def _dqK_dx_1d(self, x: np.ndarray, **kwargs) -> np.ndarray:
+        a, b = kwargs["domain"]
+        ell = kwargs["ell"]
         s5 = np.sqrt(5)
         first_exp = -np.exp(s5 * (x - b) / ell) / (15 * ell)
         first_term = first_exp * (15 * ell - 15 * s5 * (x - b) + 25 / ell * (x - b) ** 2)

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -67,17 +67,11 @@ class QuadratureRBF(QuadratureKernel):
     def qK(self, x2: np.ndarray) -> np.ndarray:
         raise NotImplementedError
 
-    def Kq(self, x1: np.ndarray) -> np.ndarray:
-        return self.qK(x1).T
-
     def qKq(self) -> float:
         raise NotImplementedError
 
     def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
         raise NotImplementedError
-
-    def dKq_dx(self, x1: np.ndarray) -> np.ndarray:
-        return self.dqK_dx(x1).T
 
     # rbf-kernel specific helper
     def _scaled_vector_diff(self, v1: np.ndarray, v2: np.ndarray, scale: float = None) -> np.ndarray:

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -16,7 +16,7 @@ from ..typing import BoundsType
 
 
 class QuadratureRBF(QuadratureKernel):
-    r"""An RBF kernel augmented with integrability.
+    r"""Base class for an RBF kernel augmented with integrability.
 
     .. math::
         k(x, x') = \sigma^2 e^{-\frac{1}{2}\frac{\|x-x'\|^2}{\lambda^2}},

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -64,15 +64,6 @@ class QuadratureRBF(QuadratureKernel):
         r"""The scale :math:`\sigma^2` of the kernel."""
         return self.kern.variance
 
-    def qK(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
-    def qKq(self) -> float:
-        raise NotImplementedError
-
-    def dqK_dx(self, x2: np.ndarray) -> np.ndarray:
-        raise NotImplementedError
-
     # rbf-kernel specific helper
     def _scaled_vector_diff(self, v1: np.ndarray, v2: np.ndarray, scale: float = None) -> np.ndarray:
         r"""Scaled element-wise vector difference between vectors v1 and v2.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

There are several product quadrature kernels in the library which follow a similar structure. Hence code was dublicated. This PR introduces a `QuadratureProductKernel` base class which gets rid of the duplicted code. No functional changes. It might be possible to do all this prettier, but it's better than before. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
