### PR TITLE
Gaussian integration measure now allows for diagonal covariance

### DIFF
--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -28,7 +28,7 @@ from ..quadrature.kernels import (
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
-from ..quadrature.measures import IntegrationMeasure, IsotropicGaussianMeasure, UniformMeasure
+from ..quadrature.measures import GaussianMeasure, IntegrationMeasure, UniformMeasure
 from ..quadrature.typing import BoundsType
 
 
@@ -676,7 +676,7 @@ def _get_qkernel_gauss(
                 measure=measure,
                 variable_names=integral_name,
             )
-        elif isinstance(measure, IsotropicGaussianMeasure):
+        elif isinstance(measure, GaussianMeasure):
             quadrature_kernel_emukit = QuadratureRBFIsoGaussMeasure(
                 rbf_kernel=standard_kernel_emukit, measure=measure, variable_names=integral_name
             )

--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -24,7 +24,7 @@ from ..quadrature.kernels import (
     QuadratureProductBrownianLebesgueMeasure,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureProductMatern52LebesgueMeasure,
-    QuadratureRBFIsoGaussMeasure,
+    QuadratureRBFGaussianMeasure,
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
@@ -677,7 +677,7 @@ def _get_qkernel_gauss(
                 variable_names=integral_name,
             )
         elif isinstance(measure, GaussianMeasure):
-            quadrature_kernel_emukit = QuadratureRBFIsoGaussMeasure(
+            quadrature_kernel_emukit = QuadratureRBFGaussianMeasure(
                 rbf_kernel=standard_kernel_emukit, measure=measure, variable_names=integral_name
             )
         else:

--- a/emukit/quadrature/acquisitions/mutual_information.py
+++ b/emukit/quadrature/acquisitions/mutual_information.py
@@ -34,6 +34,7 @@ class MutualInformation(Acquisition):
         self.model = model
         self.rho2 = SquaredCorrelation(model)
 
+    @property
     def has_gradients(self) -> bool:
         """Whether acquisition value has analytical gradient calculation available."""
         return True

--- a/emukit/quadrature/acquisitions/squared_correlation.py
+++ b/emukit/quadrature/acquisitions/squared_correlation.py
@@ -35,6 +35,7 @@ class SquaredCorrelation(Acquisition):
     def __init__(self, model: VanillaBayesianQuadrature):
         self.model = model
 
+    @property
     def has_gradients(self) -> bool:
         """Whether acquisition value has analytical gradient calculation available."""
         return True

--- a/emukit/quadrature/acquisitions/squared_correlation.py
+++ b/emukit/quadrature/acquisitions/squared_correlation.py
@@ -47,7 +47,7 @@ class SquaredCorrelation(Acquisition):
         """
         return self._evaluate(x)[0]
 
-    def _evaluate(self, x: np.ndarray) -> Tuple[np.ndarray, np.float, np.ndarray, np.ndarray]:
+    def _evaluate(self, x: np.ndarray) -> Tuple[np.ndarray, float, np.ndarray, np.ndarray]:
         """Evaluates the acquisition function at x.
 
         :param x: The locations where to evaluate, shape (n_points, input_dim) .
@@ -79,7 +79,7 @@ class SquaredCorrelation(Acquisition):
 
         return squared_correlation, squared_correlation_gradient
 
-    def _value_terms(self, x: np.ndarray) -> Tuple[np.float, np.ndarray, np.ndarray]:
+    def _value_terms(self, x: np.ndarray) -> Tuple[float, np.ndarray, np.ndarray]:
         """Computes the terms needed for the squared correlation.
 
         :param x: The locations where to evaluate, shape (n_points, input_dim).

--- a/emukit/quadrature/acquisitions/uncertainty_sampling.py
+++ b/emukit/quadrature/acquisitions/uncertainty_sampling.py
@@ -30,6 +30,7 @@ class UncertaintySampling(Acquisition):
         self.model = model
         self._measure_power = measure_power
 
+    @property
     def has_gradients(self) -> bool:
         """Whether acquisition value has analytical gradient calculation available."""
         return True

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -15,7 +15,7 @@ from .quadrature_matern32 import QuadratureProductMatern32, QuadratureProductMat
 from .quadrature_matern52 import QuadratureProductMatern52, QuadratureProductMatern52LebesgueMeasure
 from .quadrature_rbf import (
     QuadratureRBF,
-    QuadratureRBFIsoGaussMeasure,
+    QuadratureRBFGaussianMeasure,
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
@@ -27,7 +27,7 @@ __all__ = [
     "QuadratureRBF",
     "QuadratureRBFLebesgueMeasure",
     "QuadratureRBFUniformMeasure",
-    "QuadratureRBFIsoGaussMeasure",
+    "QuadratureRBFGaussianMeasure",
     "QuadratureProductKernel",
     "QuadratureProductBrownian",
     "QuadratureProductBrownianLebesgueMeasure",

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -88,7 +88,7 @@ class QuadratureKernel:
         """
         return self.qK(x1).T
 
-    def qKq(self) -> np.float:
+    def qKq(self) -> float:
         """The kernel integrated over both arguments x1 and x2.
 
         :returns: Double integrated kernel.

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -139,13 +139,13 @@ class QuadratureRBFLebesgueMeasure(QuadratureRBF):
         return self.qK(x2) * fraction
 
 
-class QuadratureRBFIsoGaussMeasure(QuadratureRBF):
-    """An RBF kernel augmented with integrability w.r.t. an isotropic Gaussian measure.
+class QuadratureRBFGaussianMeasure(QuadratureRBF):
+    """An RBF kernel augmented with integrability w.r.t. a Gaussian measure.
 
     .. seealso::
        * :class:`emukit.quadrature.interfaces.IRBF`
        * :class:`emukit.quadrature.kernels.QuadratureRBF`
-       * :class:`emukit.quadrature.measures.IsotropicGaussianMeasure`
+       * :class:`emukit.quadrature.measures.GaussianMeasure`
 
     :param rbf_kernel: The standard EmuKit rbf-kernel.
     :param measure: A Gaussian measure.

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -11,7 +11,7 @@ from scipy.special import erf
 
 from ...quadrature.interfaces.standard_kernels import IRBF
 from ..kernels import QuadratureKernel
-from ..measures import BoxDomain, IntegrationMeasure, IsotropicGaussianMeasure, UniformMeasure
+from ..measures import BoxDomain, GaussianMeasure, IntegrationMeasure, UniformMeasure
 from ..typing import BoundsType
 
 
@@ -153,7 +153,7 @@ class QuadratureRBFIsoGaussMeasure(QuadratureRBF):
 
     """
 
-    def __init__(self, rbf_kernel: IRBF, measure: IsotropicGaussianMeasure, variable_names: str = "") -> None:
+    def __init__(self, rbf_kernel: IRBF, measure: GaussianMeasure, variable_names: str = "") -> None:
         super().__init__(rbf_kernel=rbf_kernel, integral_bounds=None, measure=measure, variable_names=variable_names)
 
     def qK(self, x2: np.ndarray, scale_factor: float = 1.0) -> np.ndarray:

--- a/emukit/quadrature/measures/__init__.py
+++ b/emukit/quadrature/measures/__init__.py
@@ -1,8 +1,8 @@
 """Integration measures."""
 
 from .domain import BoxDomain
-from .gaussian_measure import IsotropicGaussianMeasure
+from .gaussian_measure import GaussianMeasure
 from .integration_measure import IntegrationMeasure
 from .uniform_measure import UniformMeasure
 
-__all__ = ["BoxDomain", "IntegrationMeasure", "UniformMeasure", "IsotropicGaussianMeasure"]
+__all__ = ["BoxDomain", "IntegrationMeasure", "UniformMeasure", "GaussianMeasure"]

--- a/emukit/quadrature/methods/bounded_bq_model.py
+++ b/emukit/quadrature/methods/bounded_bq_model.py
@@ -5,7 +5,7 @@ from typing import Optional, Tuple
 import numpy as np
 
 from ..interfaces.base_gp import IBaseGaussianProcess
-from ..kernels.quadrature_rbf import QuadratureRBFIsoGaussMeasure
+from ..kernels.quadrature_rbf import QuadratureRBFGaussianMeasure
 from .warped_bq_model import WarpedBayesianQuadratureModel
 from .warpings import SquareRootWarping
 
@@ -62,7 +62,7 @@ class BoundedBayesianQuadrature(WarpedBayesianQuadratureModel):
 
         # The integrate method is specific to QuadratureRBFIsoGaussMeasure, predict methods are only specific to
         # the approximation method used (Taylor expansion of the GP in this case).
-        if not isinstance(base_gp.kern, QuadratureRBFIsoGaussMeasure):
+        if not isinstance(base_gp.kern, QuadratureRBFGaussianMeasure):
             raise ValueError(
                 f"{self.__class__.__name__} can only be used with QuadratureRBFIsoGaussMeasure kernel. "
                 f"Instead {type(base_gp.kern)} is given."

--- a/integration_tests/emukit/quadrature/test_wsabil_loop.py
+++ b/integration_tests/emukit/quadrature/test_wsabil_loop.py
@@ -7,7 +7,7 @@ from pytest_lazyfixture import lazy_fixture
 from emukit.core.loop.user_function import UserFunctionWrapper
 from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, QuadratureRBFIsoGaussMeasure, RBFGPy
 from emukit.quadrature.loop import WSABILLoop
-from emukit.quadrature.measures import IsotropicGaussianMeasure
+from emukit.quadrature.measures import GaussianMeasure
 from emukit.quadrature.methods import WSABIL
 
 
@@ -20,7 +20,7 @@ def base_gp_data():
     X = np.array([[-1, 1], [0, 0], [-2, 0.1]])
     Y = np.array([[1], [2], [3]])
     gpy_model = GPy.models.GPRegression(X=X, Y=Y, kernel=GPy.kern.RBF(input_dim=X.shape[1]))
-    measure = IsotropicGaussianMeasure(mean=np.array([0.1, 1.8]), variance=0.8)
+    measure = GaussianMeasure(mean=np.array([0.1, 1.8]), variance=0.8)
     qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
     base_gp = BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model)
     return base_gp, X, Y

--- a/integration_tests/emukit/quadrature/test_wsabil_loop.py
+++ b/integration_tests/emukit/quadrature/test_wsabil_loop.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_equal
 from pytest_lazyfixture import lazy_fixture
 
 from emukit.core.loop.user_function import UserFunctionWrapper
-from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, QuadratureRBFIsoGaussMeasure, RBFGPy
+from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, QuadratureRBFGaussianMeasure, RBFGPy
 from emukit.quadrature.loop import WSABILLoop
 from emukit.quadrature.measures import GaussianMeasure
 from emukit.quadrature.methods import WSABIL
@@ -21,7 +21,7 @@ def base_gp_data():
     Y = np.array([[1], [2], [3]])
     gpy_model = GPy.models.GPRegression(X=X, Y=Y, kernel=GPy.kern.RBF(input_dim=X.shape[1]))
     measure = GaussianMeasure(mean=np.array([0.1, 1.8]), variance=0.8)
-    qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
+    qrbf = QuadratureRBFGaussianMeasure(RBFGPy(gpy_model.kern), measure=measure)
     base_gp = BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model)
     return base_gp, X, Y
 

--- a/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
+++ b/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
@@ -23,7 +23,7 @@ from emukit.quadrature.kernels import (
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
-from emukit.quadrature.measures import IsotropicGaussianMeasure, UniformMeasure
+from emukit.quadrature.measures import GaussianMeasure, UniformMeasure
 
 
 def get_prod_kernel(kernel_type, n_dim):
@@ -46,7 +46,7 @@ def measure_lebesgue(n_dim: int):
 
 
 def measure_gaussiso(n_dim: int):
-    return IsotropicGaussianMeasure(mean=np.ones(n_dim), variance=1.0)
+    return GaussianMeasure(mean=np.ones(n_dim), variance=1.0)
 
 
 def measure_uniform(n_dim: int):

--- a/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
+++ b/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
@@ -19,7 +19,7 @@ from emukit.quadrature.kernels import (
     QuadratureProductBrownianLebesgueMeasure,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureProductMatern52LebesgueMeasure,
-    QuadratureRBFIsoGaussMeasure,
+    QuadratureRBFGaussianMeasure,
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
@@ -131,7 +131,7 @@ def wrapper_rbf_1(dim2, gpy_rbf):
 
 @pytest.fixture
 def wrapper_rbf_2(dim2, gpy_rbf):
-    return get_wrapper_dict(dim2, measure_gaussiso, None, gpy_rbf, RBFGPy, QuadratureRBFIsoGaussMeasure)
+    return get_wrapper_dict(dim2, measure_gaussiso, None, gpy_rbf, RBFGPy, QuadratureRBFGaussianMeasure)
 
 
 @pytest.fixture

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -111,13 +111,13 @@ if __name__ == "__main__":
 
     # === Choose MEASURE BELOW ======
     # MEASURE_INTBOUNDS = "Lebesgue-finite"
-    MEASURE_INTBOUNDS = 'Gaussian-infinite'
+    MEASURE_INTBOUNDS = "Gaussian-infinite"
     # MEASURE_INTBOUNDS = 'Uniform-infinite'
     # MEASURE_INTBOUNDS = "Uniform-finite"
     # === CHOOSE MEASURE ABOVE ======
 
     # === Choose KERNEL BELOW ======
-    KERNEL = 'rbf'
+    KERNEL = "rbf"
     # KERNEL = "matern32"
     # KERNEL = "matern52"
     # KERNEL = "brownian"

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -12,7 +12,7 @@ from test_quadrature_kernels import (
     get_qmatern32_lebesque,
     get_qmatern52_lebesque,
     get_qprodbrownian_lebesque,
-    get_qrbf_gauss_iso,
+    get_qrbf_gaussian,
     get_qrbf_lebesque,
     get_qrbf_uniform_finite,
     get_qrbf_uniform_infinite,
@@ -31,8 +31,8 @@ def _sample_uniform(num_samples: int, bounds: List[Tuple[float, float]]) -> np.n
     return samples_shifted
 
 
-def _sample_gauss_iso(num_samples: int, measure: GaussianMeasure) -> np.ndarray:
-    D = measure.num_dimensions
+def _sample_gaussian(num_samples: int, measure: GaussianMeasure) -> np.ndarray:
+    D = measure.input_dim
     samples = np.reshape(np.random.randn(num_samples * D), [num_samples, D])
     return measure.mean + np.sqrt(measure.variance) * samples
 
@@ -58,18 +58,18 @@ def qKq_lebesgue(num_samples: int, qkern: QuadratureKernel) -> float:
     return np.mean(qKx) * volume
 
 
-def qK_gauss_iso(num_samples: int, qkern: QuadratureKernel, x2: np.ndarray) -> np.ndarray:
-    """MC estimator for kernel mean qK on isotropic Gaussian measure."""
+def qK_gaussian(num_samples: int, qkern: QuadratureKernel, x2: np.ndarray) -> np.ndarray:
+    """MC estimator for kernel mean qK on Gaussian measure."""
     measure = qkern.measure
-    samples = _sample_gauss_iso(num_samples, measure)
+    samples = _sample_gaussian(num_samples, measure)
     Kx = qkern.K(samples, x2)
     return np.mean(Kx, axis=0)
 
 
-def qKq_gauss_iso(num_samples: int, qkern: QuadratureKernel) -> float:
-    """MC estimator for initial error qKq on isotropic Gaussian measure."""
+def qKq_gaussian(num_samples: int, qkern: QuadratureKernel) -> float:
+    """MC estimator for initial error qKq on Gaussian measure."""
     measure = qkern.measure
-    samples = _sample_gauss_iso(num_samples, measure)
+    samples = _sample_gaussian(num_samples, measure)
     qKx = qkern.qK(samples)
     return np.mean(qKx)
 
@@ -110,26 +110,26 @@ if __name__ == "__main__":
     np.random.seed(0)
 
     # === Choose MEASURE BELOW ======
-    MEASURE_INTBOUNDS = "Lebesgue-finite"
-    # MEASURE_INTBOUNDS = 'GaussIso-infinite'
+    # MEASURE_INTBOUNDS = "Lebesgue-finite"
+    MEASURE_INTBOUNDS = 'Gaussian-infinite'
     # MEASURE_INTBOUNDS = 'Uniform-infinite'
     # MEASURE_INTBOUNDS = "Uniform-finite"
     # === CHOOSE MEASURE ABOVE ======
 
     # === Choose KERNEL BELOW ======
-    # KERNEL = 'rbf'
+    KERNEL = 'rbf'
     # KERNEL = "matern32"
     # KERNEL = "matern52"
     # KERNEL = "brownian"
-    KERNEL = "prodbrownian"
+    # KERNEL = "prodbrownian"
     # === CHOOSE KERNEL ABOVE ======
 
     _e = "Kernel embedding not implemented."
     if KERNEL == "rbf":
         if MEASURE_INTBOUNDS == "Lebesgue-finite":
             emukit_qkern, dat = get_qrbf_lebesque()
-        elif MEASURE_INTBOUNDS == "GaussIso-infinite":
-            emukit_qkern, dat = get_qrbf_gauss_iso()
+        elif MEASURE_INTBOUNDS == "Gaussian-infinite":
+            emukit_qkern, dat = get_qrbf_gaussian()
         elif MEASURE_INTBOUNDS == "Uniform-infinite":
             emukit_qkern, dat = get_qrbf_uniform_infinite()
         elif MEASURE_INTBOUNDS == "Uniform-finite":
@@ -169,8 +169,8 @@ if __name__ == "__main__":
 
         if MEASURE_INTBOUNDS == "Lebesgue-finite":
             qK_samples = qK_lebesgue(num_samples, emukit_qkern, dat.x2)
-        elif MEASURE_INTBOUNDS == "GaussIso-infinite":
-            qK_samples = qK_gauss_iso(num_samples, emukit_qkern, dat.x2)
+        elif MEASURE_INTBOUNDS == "Gaussian-infinite":
+            qK_samples = qK_gaussian(num_samples, emukit_qkern, dat.x2)
         elif MEASURE_INTBOUNDS == "Uniform-infinite":
             qK_samples = qK_uniform(num_samples, emukit_qkern, dat.x2)
         elif MEASURE_INTBOUNDS == "Uniform-finite":
@@ -205,8 +205,8 @@ if __name__ == "__main__":
 
         if MEASURE_INTBOUNDS == "Lebesgue-finite":
             qKq_samples = qKq_lebesgue(num_samples, emukit_qkern)
-        elif MEASURE_INTBOUNDS == "GaussIso-infinite":
-            qKq_samples = qKq_gauss_iso(num_samples, emukit_qkern)
+        elif MEASURE_INTBOUNDS == "Gaussian-infinite":
+            qKq_samples = qKq_gaussian(num_samples, emukit_qkern)
         elif MEASURE_INTBOUNDS == "Uniform-infinite":
             qKq_samples = qKq_uniform(num_samples, emukit_qkern)
         elif MEASURE_INTBOUNDS == "Uniform-finite":

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -19,7 +19,7 @@ from test_quadrature_kernels import (
 )
 
 from emukit.quadrature.kernels import QuadratureKernel
-from emukit.quadrature.measures import IsotropicGaussianMeasure
+from emukit.quadrature.measures import GaussianMeasure
 
 
 def _sample_uniform(num_samples: int, bounds: List[Tuple[float, float]]) -> np.ndarray:
@@ -31,7 +31,7 @@ def _sample_uniform(num_samples: int, bounds: List[Tuple[float, float]]) -> np.n
     return samples_shifted
 
 
-def _sample_gauss_iso(num_samples: int, measure: IsotropicGaussianMeasure) -> np.ndarray:
+def _sample_gauss_iso(num_samples: int, measure: GaussianMeasure) -> np.ndarray:
     D = measure.num_dimensions
     samples = np.reshape(np.random.randn(num_samples * D), [num_samples, D])
     return measure.mean + np.sqrt(measure.variance) * samples

--- a/tests/emukit/quadrature/test_measures.py
+++ b/tests/emukit/quadrature/test_measures.py
@@ -111,8 +111,8 @@ def test_uniform_measure_wrong_bounds():
 
 
 def test_gauss_measure_values(gauss_measure, gauss_iso_measure):
-    assert gauss_iso_measure.is_isotropic
-    assert not gauss_measure.is_isotropic
+    assert gauss_iso_measure.measure.is_isotropic
+    assert not gauss_measure.measure.is_isotropic
 
 
 @pytest.mark.parametrize(

--- a/tests/emukit/quadrature/test_measures.py
+++ b/tests/emukit/quadrature/test_measures.py
@@ -8,7 +8,7 @@ import pytest
 from pytest_lazyfixture import lazy_fixture
 from utils import check_grad
 
-from emukit.quadrature.measures import IsotropicGaussianMeasure, UniformMeasure
+from emukit.quadrature.measures import GaussianMeasure, UniformMeasure
 
 REL_TOL = 1e-5
 ABS_TOL = 1e-4
@@ -25,10 +25,19 @@ class DataUniformMeasure:
 @dataclass
 class DataGaussIsoMeasure:
     D = 2
-    mean = np.arange(D)
-    variance = 0.5
-    measure = IsotropicGaussianMeasure(mean=mean, variance=variance)
+    mean = np.array([0, 0.8])
+    variance = 0.6
+    measure = GaussianMeasure(mean=mean, variance=variance)
     dat_bounds = [(m - 2 * np.sqrt(0.5), m + 2 * np.sqrt(0.5)) for m in mean]
+
+
+@dataclass
+class DataGaussMeasure:
+    D = 2
+    mean = np.array([0, 0.8])
+    variance = np.array([0.2, 1.4])
+    measure = GaussianMeasure(mean=mean, variance=variance)
+    dat_bounds = [(m - 2 * np.sqrt(v), m + 2 * np.sqrt(v)) for m, v in zip(mean, variance)]
 
 
 @pytest.fixture()
@@ -41,9 +50,15 @@ def gauss_iso_measure():
     return DataGaussIsoMeasure()
 
 
+@pytest.fixture()
+def gauss_measure():
+    return DataGaussMeasure()
+
+
 measure_test_list = [
     lazy_fixture("uniform_measure"),
     lazy_fixture("gauss_iso_measure"),
+    lazy_fixture("gauss_measure"),
 ]
 
 
@@ -92,19 +107,35 @@ def test_uniform_measure_wrong_bounds():
         UniformMeasure(bounds)
 
 
-# == tests specific to gauss iso measure start here
+# == tests specific to gaussian measure start here
 
 
-def test_iso_gauss_measure_invalid_input():
-    var_wrong_value = -2.0
+def test_gauss_measure_values(gauss_measure, gauss_iso_measure):
+    assert gauss_iso_measure.is_isotropic
+    assert not gauss_measure.is_isotropic
+
+
+@pytest.mark.parametrize(
+    "wrong_input",
+    [
+        (np.ones(3), -2.0),
+        (np.ones(3), -np.array([0.0, 1.0, 2.0])),
+        (np.ones(3), -np.array([1.0, -1.0, 2.0])),
+        (np.ones(3), -np.array([1.0, 2.0])),
+        (np.ones(3), -np.array([1.0, -1.0, 2.0])[:, None]),
+    ],
+)
+def test_gauss_measure_invalid_variance_raises(wrong_input):
+    mean, var_wrong_value = wrong_input
+    with pytest.raises(ValueError):
+        GaussianMeasure(mean=mean, variance=var_wrong_value)
+
+
+def test_gauss_measure_invalid_mean_raises():
     mean_wrong_shape = np.ones([3, 1])
+    with pytest.raises(ValueError):
+        GaussianMeasure(mean=mean_wrong_shape, variance=1.0)
+
     mean_wrong_type = 0.0
-
-    with pytest.raises(ValueError):
-        IsotropicGaussianMeasure(mean=np.ones(3), variance=var_wrong_value)
-
     with pytest.raises(TypeError):
-        IsotropicGaussianMeasure(mean=mean_wrong_type, variance=1.0)
-
-    with pytest.raises(ValueError):
-        IsotropicGaussianMeasure(mean=mean_wrong_shape, variance=1.0)
+        GaussianMeasure(mean=mean_wrong_type, variance=1.0)

--- a/tests/emukit/quadrature/test_quadrature_acquisitions.py
+++ b/tests/emukit/quadrature/test_quadrature_acquisitions.py
@@ -11,7 +11,7 @@ from utils import check_grad
 from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, RBFGPy
 from emukit.quadrature.acquisitions import IntegralVarianceReduction, MutualInformation, UncertaintySampling
 from emukit.quadrature.kernels.quadrature_rbf import QuadratureRBFIsoGaussMeasure, QuadratureRBFLebesgueMeasure
-from emukit.quadrature.measures import IsotropicGaussianMeasure
+from emukit.quadrature.measures import GaussianMeasure
 from emukit.quadrature.methods import VanillaBayesianQuadrature
 
 
@@ -36,7 +36,7 @@ def model(gpy_model):
 @pytest.fixture
 def model_with_density(gpy_model):
     x_init, y_init = gpy_model.X, gpy_model.Y
-    measure = IsotropicGaussianMeasure(mean=np.arange(x_init.shape[1]), variance=2.0)
+    measure = GaussianMeasure(mean=np.arange(x_init.shape[1]), variance=2.0)
     qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
     basegp = BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model)
     return VanillaBayesianQuadrature(base_gp=basegp, X=x_init, Y=y_init)

--- a/tests/emukit/quadrature/test_quadrature_acquisitions.py
+++ b/tests/emukit/quadrature/test_quadrature_acquisitions.py
@@ -10,7 +10,7 @@ from utils import check_grad
 
 from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, RBFGPy
 from emukit.quadrature.acquisitions import IntegralVarianceReduction, MutualInformation, UncertaintySampling
-from emukit.quadrature.kernels.quadrature_rbf import QuadratureRBFIsoGaussMeasure, QuadratureRBFLebesgueMeasure
+from emukit.quadrature.kernels.quadrature_rbf import QuadratureRBFGaussianMeasure, QuadratureRBFLebesgueMeasure
 from emukit.quadrature.measures import GaussianMeasure
 from emukit.quadrature.methods import VanillaBayesianQuadrature
 
@@ -37,7 +37,7 @@ def model(gpy_model):
 def model_with_density(gpy_model):
     x_init, y_init = gpy_model.X, gpy_model.Y
     measure = GaussianMeasure(mean=np.arange(x_init.shape[1]), variance=2.0)
-    qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
+    qrbf = QuadratureRBFGaussianMeasure(RBFGPy(gpy_model.kern), measure=measure)
     basegp = BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model)
     return VanillaBayesianQuadrature(base_gp=basegp, X=x_init, Y=y_init)
 

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -27,7 +27,7 @@ from emukit.quadrature.kernels import (
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
-from emukit.quadrature.measures import IsotropicGaussianMeasure, UniformMeasure
+from emukit.quadrature.measures import GaussianMeasure, UniformMeasure
 
 
 # the following classes and functions are also used to compute the ground truth integrals with MC
@@ -147,7 +147,7 @@ def get_qrbf_lebesque():
 
 def get_qrbf_gauss_iso():
     dat = DataGaussIso()
-    measure = IsotropicGaussianMeasure(mean=dat.measure_mean, variance=dat.measure_var)
+    measure = GaussianMeasure(mean=dat.measure_mean, variance=dat.measure_var)
     qkern = QuadratureRBFIsoGaussMeasure(EmukitRBF().kern, measure=measure)
     return qkern, dat
 

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -23,7 +23,7 @@ from emukit.quadrature.kernels import (
     QuadratureProductBrownianLebesgueMeasure,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureProductMatern52LebesgueMeasure,
-    QuadratureRBFIsoGaussMeasure,
+    QuadratureRBFGaussianMeasure,
     QuadratureRBFLebesgueMeasure,
     QuadratureRBFUniformMeasure,
 )
@@ -68,15 +68,15 @@ class DataPositiveDomain:
 
 
 @dataclass
-class DataGaussIso:
+class DataGaussian:
     D = 2
     measure_mean = np.array([0.2, 1.3])
-    measure_var = 2.0
+    measure_var = np.array([0.3, 1.4])
     x1 = np.array([[-1, 1], [0, 0.1], [0.5, -1.5]])
     x2 = np.array([[-1, 1], [0, 0.2], [0.8, -0.1], [1.3, 2.8]])
     N = 3
     M = 4
-    dat_bounds = [(m - 2 * np.sqrt(2), m + 2 * np.sqrt(2)) for m in measure_mean]
+    dat_bounds = [(m - 2 * np.sqrt(v), m + 2 * np.sqrt(v)) for m, v in zip(measure_mean, measure_var)]
 
 
 @dataclass
@@ -145,10 +145,10 @@ def get_qrbf_lebesque():
     return qkern, dat
 
 
-def get_qrbf_gauss_iso():
-    dat = DataGaussIso()
+def get_qrbf_gaussian():
+    dat = DataGaussian()
     measure = GaussianMeasure(mean=dat.measure_mean, variance=dat.measure_var)
-    qkern = QuadratureRBFIsoGaussMeasure(EmukitRBF().kern, measure=measure)
+    qkern = QuadratureRBFGaussianMeasure(EmukitRBF().kern, measure=measure)
     return qkern, dat
 
 
@@ -198,8 +198,8 @@ def qrbf_lebesgue():
 
 
 @pytest.fixture
-def qrbf_gauss_iso():
-    qkern, dat = get_qrbf_gauss_iso()
+def qrbf_gaussian():
+    qkern, dat = get_qrbf_gaussian()
     return qkern, dat.x1, dat.x2, dat.N, dat.M, dat.D, dat.dat_bounds
 
 
@@ -241,7 +241,7 @@ def qprodbrownian_lebesque():
 
 embeddings_test_list = [
     lazy_fixture("qrbf_lebesgue"),
-    lazy_fixture("qrbf_gauss_iso"),
+    lazy_fixture("qrbf_gaussian"),
     lazy_fixture("qrbf_uniform_infinite"),
     lazy_fixture("qrbf_uniform_finite"),
     lazy_fixture("qmatern32_lebesgue"),
@@ -272,7 +272,7 @@ def test_qkernel_shapes(kernel_embedding):
     "kernel_embedding,interval",
     [
         (embeddings_test_list[0], [38.267217898004176, 38.32112525041843]),
-        (embeddings_test_list[1], [0.10107780172175222, 0.10132860168906656]),
+        (embeddings_test_list[1], [0.22019471616760106, 0.22056701590213823]),
         (embeddings_test_list[2], [0.19925694197982124, 0.19946236996755512]),
         (embeddings_test_list[3], [0.15840594393483423, 0.16003690383217276]),
         (embeddings_test_list[4], [33.6816570527734, 33.726646173769595]),
@@ -310,10 +310,10 @@ def test_qkernel_qKq(kernel_embedding, interval):
             embeddings_test_list[1],
             np.array(
                 [
-                    [0.12486974030387826, 0.125750078406417],
-                    [0.13992078671537916, 0.14081149568263046],
-                    [0.11892561016472149, 0.1197587877306684],
-                    [0.09729471848600614, 0.09804968814418509],
+                    [0.13947611219369957, 0.14011691061322437],
+                    [0.2451677448342577, 0.24601121206543616],
+                    [0.18304341553566297, 0.1838963624576538],
+                    [0.11108022737109795, 0.11170403633365646],
                 ]
             ),
         ),

--- a/tests/emukit/quadrature/test_quadrature_models.py
+++ b/tests/emukit/quadrature/test_quadrature_models.py
@@ -9,7 +9,7 @@ from pytest_lazyfixture import lazy_fixture
 from utils import check_grad
 
 from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, RBFGPy
-from emukit.quadrature.kernels import QuadratureRBFIsoGaussMeasure, QuadratureRBFLebesgueMeasure
+from emukit.quadrature.kernels import QuadratureRBFGaussianMeasure, QuadratureRBFLebesgueMeasure
 from emukit.quadrature.measures import GaussianMeasure
 from emukit.quadrature.methods import WSABIL, BoundedBayesianQuadrature
 from emukit.quadrature.methods.vanilla_bq import VanillaBayesianQuadrature
@@ -38,7 +38,7 @@ def get_gpy_model():
 def get_base_gp():
     gpy_model, dat = get_gpy_model()
     measure = GaussianMeasure(mean=dat.measure_mean, variance=dat.measure_var)
-    qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
+    qrbf = QuadratureRBFGaussianMeasure(RBFGPy(gpy_model.kern), measure=measure)
     return BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model), dat
 
 

--- a/tests/emukit/quadrature/test_quadrature_models.py
+++ b/tests/emukit/quadrature/test_quadrature_models.py
@@ -10,7 +10,7 @@ from utils import check_grad
 
 from emukit.model_wrappers.gpy_quadrature_wrappers import BaseGaussianProcessGPy, RBFGPy
 from emukit.quadrature.kernels import QuadratureRBFIsoGaussMeasure, QuadratureRBFLebesgueMeasure
-from emukit.quadrature.measures import IsotropicGaussianMeasure
+from emukit.quadrature.measures import GaussianMeasure
 from emukit.quadrature.methods import WSABIL, BoundedBayesianQuadrature
 from emukit.quadrature.methods.vanilla_bq import VanillaBayesianQuadrature
 
@@ -37,7 +37,7 @@ def get_gpy_model():
 
 def get_base_gp():
     gpy_model, dat = get_gpy_model()
-    measure = IsotropicGaussianMeasure(mean=dat.measure_mean, variance=dat.measure_var)
+    measure = GaussianMeasure(mean=dat.measure_mean, variance=dat.measure_var)
     qrbf = QuadratureRBFIsoGaussMeasure(RBFGPy(gpy_model.kern), measure=measure)
     return BaseGaussianProcessGPy(kern=qrbf, gpy_model=gpy_model), dat
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A function f is integrated w.r.t. an integration measure p, for example the Gaussian measure. EmuKit so far allowed the Gaussian integration measure only to have a scalar covariance (isotropic). This was a quite big limitation. This PR extends the measure to allow for diagonal covariance matrices as well. The kernel embedding for the RBF kernel is adjusted as well (this is the only kernel that had an existing kernel embedding w.r.t. Gaussian measure). Tests and docs are adjusted, too.

Visible (user facing) changes are:
- `IsotropicGaussianMeasure` rename to `GaussianMeasure`, its property `variance` is now a 1d array instead of a scalar.
- `QuadratureRBFIsoGaussMeasure` renamed to `QuadratureRBFGaussianMeasure`

It is still possible to obtain the previous functionality by simply instantiating the Gaussian measure with a scalar variance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
