### PR TITLE
`ProductMatern12` kernel embedding w.r.t Lebesgue measure & GPy wrapper

### DIFF
--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -225,10 +225,10 @@ class ProductMatern12GPy(IProductMatern12):
         """The kernel k(x1, x2) evaluated at x1 and x2 computed as product from the
         individual 1d kernels.
 
-        :param x1: First argument of the kernel.
-        :param x2: Second argument of the kernel.
+        :param x1: First argument of the kernel, shape (n_points N, input_dim)
+        :param x2: Second argument of the kernel, shape (n_points M, input_dim)
         :param skip: Skip these dimensions if specified.
-        :returns: Kernel evaluated at x1, x2.
+        :returns: Kernel evaluated at x1, x2, shape (N, M).
         """
         if skip is None:
             skip = []
@@ -336,10 +336,10 @@ class ProductMatern32GPy(IProductMatern32):
         """The kernel k(x1, x2) evaluated at x1 and x2 computed as product from the
         individual 1d kernels.
 
-        :param x1: First argument of the kernel.
-        :param x2: Second argument of the kernel.
+        :param x1: First argument of the kernel, shape (n_points N, input_dim)
+        :param x2: Second argument of the kernel, shape (n_points M, input_dim)
         :param skip: Skip these dimensions if specified.
-        :returns: Kernel evaluated at x1, x2.
+        :returns: Kernel evaluated at x1, x2, shape (N, M).
         """
         if skip is None:
             skip = []
@@ -447,10 +447,10 @@ class ProductMatern52GPy(IProductMatern52):
         """The kernel k(x1, x2) evaluated at x1 and x2 computed as product from the
         individual 1d kernels.
 
-        :param x1: First argument of the kernel.
-        :param x2: Second argument of the kernel.
+        :param x1: First argument of the kernel, shape (n_points N, input_dim)
+        :param x2: Second argument of the kernel, shape (n_points M, input_dim)
         :param skip: Skip these dimensions if specified.
-        :returns: Kernel evaluated at x1, x2.
+        :returns: Kernel evaluated at x1, x2, shape (N, M).
         """
         if skip is None:
             skip = []
@@ -576,10 +576,10 @@ class ProductBrownianGPy(IProductBrownian):
         """The kernel k(x1, x2) with offset=0 evaluated at x1 and x2 computed as product from the
         individual 1d kernels.
 
-        :param x1: First argument of the kernel.
-        :param x2: Second shifted argument of the kernel.
+        :param x1: First argument of the kernel, shape (n_points N, input_dim)
+        :param x2: Second argument of the kernel, shape (n_points M, input_dim)
         :param skip: Skip these dimensions if specified.
-        :returns: Kernel evaluated at x1, x2.
+        :returns: Kernel evaluated at x1, x2, shape (N, M).
         """
         if skip is None:
             skip = []

--- a/emukit/quadrature/interfaces/__init__.py
+++ b/emukit/quadrature/interfaces/__init__.py
@@ -9,6 +9,7 @@ from .standard_kernels import (  # noqa: F401
     IRBF,
     IBrownian,
     IProductBrownian,
+    IProductMatern12,
     IProductMatern32,
     IProductMatern52,
     IStandardKernel,
@@ -20,6 +21,7 @@ __all__ = [
     "IBrownian",
     "IRBF",
     "IProductBrownian",
+    "IProductMatern12",
     "IProductMatern32",
     "IProductMatern52",
 ]

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -16,6 +16,7 @@ from .quadrature_brownian import (
     QuadratureProductBrownian,
     QuadratureProductBrownianLebesgueMeasure,
 )
+from .quadrature_matern12 import QuadratureProductMatern12, QuadratureProductMatern12LebesgueMeasure
 from .quadrature_matern32 import QuadratureProductMatern32, QuadratureProductMatern32LebesgueMeasure
 from .quadrature_matern52 import QuadratureProductMatern52, QuadratureProductMatern52LebesgueMeasure
 from .quadrature_rbf import QuadratureRBF, QuadratureRBFGaussianMeasure, QuadratureRBFLebesgueMeasure
@@ -34,6 +35,8 @@ __all__ = [
     "QuadratureProductMatern52LebesgueMeasure",
     "QuadratureProductMatern32",
     "QuadratureProductMatern32LebesgueMeasure",
+    "QuadratureProductMatern12",
+    "QuadratureProductMatern12LebesgueMeasure",
     "QuadratureProductBrownian",
     "QuadratureProductBrownianLebesgueMeasure",
 ]

--- a/emukit/quadrature/kernels/quadrature_matern12.py
+++ b/emukit/quadrature/kernels/quadrature_matern12.py
@@ -82,13 +82,13 @@ class QuadratureProductMatern12LebesgueMeasure(QuadratureProductMatern12, Lebesg
     def _get_univariate_parameters(self, dim: int) -> dict:
         return {
             "domain": self.measure.domain.bounds[dim],
-            "ell": self.lengthscales[dim],
+            "lengthscale": self.lengthscales[dim],
             "normalize": self.measure.is_normalized,
         }
 
     def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         first_term = -np.exp((a - x) / ell)
         second_term = -np.exp((x - b) / ell)
@@ -96,14 +96,14 @@ class QuadratureProductMatern12LebesgueMeasure(QuadratureProductMatern12, Lebesg
 
     def _qKq_1d(self, **parameters) -> float:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         qKq = 2.0 * ell * ((b - a) + ell * (np.exp(-(b - a) / ell) - 1.0))
         return float(qKq) * normalization**2
 
     def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         first_term = np.exp((a - x) / ell)
         second_term = -np.exp((x - b) / ell)

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -82,13 +82,13 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32, Lebesg
     def _get_univariate_parameters(self, dim: int) -> dict:
         return {
             "domain": self.measure.domain.bounds[dim],
-            "ell": self.lengthscales[dim],
+            "lengthscale": self.lengthscales[dim],
             "normalize": self.measure.is_normalized,
         }
 
     def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         s3 = np.sqrt(3.0)
         first_term = 4.0 * ell / s3
@@ -98,7 +98,7 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32, Lebesg
 
     def _qKq_1d(self, **parameters) -> float:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         c = np.sqrt(3.0) * (b - a)
         qKq = 2.0 * ell / 3.0 * (2.0 * c - 3.0 * ell + np.exp(-c / ell) * (c + 3.0 * ell))
@@ -106,7 +106,7 @@ class QuadratureProductMatern32LebesgueMeasure(QuadratureProductMatern32, Lebesg
 
     def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         s3 = np.sqrt(3)
         exp_term_b = np.exp(s3 * (x - b) / ell)

--- a/emukit/quadrature/kernels/quadrature_matern52.py
+++ b/emukit/quadrature/kernels/quadrature_matern52.py
@@ -82,13 +82,13 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52, Lebesg
     def _get_univariate_parameters(self, dim: int) -> dict:
         return {
             "domain": self.measure.domain.bounds[dim],
-            "ell": self.lengthscales[dim],
+            "lengthscale": self.lengthscales[dim],
             "normalize": self.measure.is_normalized,
         }
 
     def _qK_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         s5 = np.sqrt(5)
         first_term = 16 * ell / (3 * s5)
@@ -102,7 +102,7 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52, Lebesg
 
     def _qKq_1d(self, **parameters) -> float:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         c = np.sqrt(5) * (b - a)
         bracket_term = 5 * a**2 - 10 * a * b + 5 * b**2 + 7 * c * ell + 15 * ell**2
@@ -111,7 +111,7 @@ class QuadratureProductMatern52LebesgueMeasure(QuadratureProductMatern52, Lebesg
 
     def _dqK_dx_1d(self, x: np.ndarray, **parameters) -> np.ndarray:
         a, b = parameters["domain"]
-        ell = parameters["ell"]
+        ell = parameters["lengthscale"]
         normalization = 1 / (b - a) if parameters["normalize"] else 1.0
         s5 = np.sqrt(5)
         first_exp = -np.exp(s5 * (x - b) / ell) / (15 * ell)

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -141,16 +141,16 @@ class QuadratureRBFGaussianMeasure(QuadratureRBF, GaussianEmbedding):
         super().__init__(rbf_kernel=rbf_kernel, measure=measure, variable_names=variable_names)
 
     def qK(self, x2: np.ndarray, scale_factor: float = 1.0) -> np.ndarray:
-        ells = scale_factor * self.lengthscales
+        lengthscales = scale_factor * self.lengthscales
         sigma2 = self.measure.variance
         mu = self.measure.mean
-        factor = np.sqrt(ells**2 / (ells**2 + sigma2)).prod()
-        scaled_norm_sq = np.power(self._scaled_vector_diff(x2, mu, np.sqrt(ells**2 + sigma2)), 2).sum(axis=1)
+        factor = np.sqrt(lengthscales**2 / (lengthscales**2 + sigma2)).prod()
+        scaled_norm_sq = np.power(self._scaled_vector_diff(x2, mu, np.sqrt(lengthscales**2 + sigma2)), 2).sum(axis=1)
         return (self.variance * factor) * np.exp(-scaled_norm_sq).reshape(1, -1)
 
     def qKq(self) -> float:
-        ells = self.lengthscales
-        qKq = np.sqrt(ells**2 / (ells**2 + 2 * self.measure.variance)).prod()
+        lengthscales = self.lengthscales
+        qKq = np.sqrt(lengthscales**2 / (lengthscales**2 + 2 * self.measure.variance)).prod()
         return self.variance * float(qKq)
 
     def dqK_dx(self, x2: np.ndarray) -> np.ndarray:

--- a/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
+++ b/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
@@ -9,6 +9,7 @@ from emukit.model_wrappers.gpy_quadrature_wrappers import (
     BaseGaussianProcessGPy,
     BrownianGPy,
     ProductBrownianGPy,
+    ProductMatern12GPy,
     ProductMatern32GPy,
     ProductMatern52GPy,
     RBFGPy,
@@ -17,6 +18,7 @@ from emukit.model_wrappers.gpy_quadrature_wrappers import (
 from emukit.quadrature.kernels import (
     QuadratureBrownianLebesgueMeasure,
     QuadratureProductBrownianLebesgueMeasure,
+    QuadratureProductMatern12LebesgueMeasure,
     QuadratureProductMatern32LebesgueMeasure,
     QuadratureProductMatern52LebesgueMeasure,
     QuadratureRBFGaussianMeasure,
@@ -67,6 +69,12 @@ def gpy_brownian(dim1):
 
 
 @pytest.fixture
+def gpy_matern12(dim1):
+    kernel_type = GPy.kern.Exponential
+    return kernel_type(input_dim=dim1), kernel_type, False
+
+
+@pytest.fixture
 def gpy_matern32(dim1):
     kernel_type = GPy.kern.Matern32
     return kernel_type(input_dim=dim1), kernel_type, False
@@ -88,6 +96,12 @@ def gpy_rbf(dim2):
 @pytest.fixture
 def gpy_prodbrownian(dim2):
     kernel_type = GPy.kern.Brownian
+    return get_prod_kernel(kernel_type, dim2), kernel_type, True
+
+
+@pytest.fixture
+def gpy_prodmatern12(dim2):
+    kernel_type = GPy.kern.Exponential
     return get_prod_kernel(kernel_type, dim2), kernel_type, True
 
 
@@ -140,6 +154,21 @@ def wrapper_brownian_2(dim2, gpy_prodbrownian):
     )
 
 
+# === Product Matern12 wrapper test cases
+@pytest.fixture
+def wrapper_matern12_1(dim2, gpy_prodmatern12):
+    return get_wrapper_dict(
+        dim2, measure_lebesgue, gpy_prodmatern12, ProductMatern12GPy, QuadratureProductMatern12LebesgueMeasure
+    )
+
+
+@pytest.fixture
+def wrapper_matern12_2(dim1, gpy_matern12):
+    return get_wrapper_dict(
+        dim1, measure_lebesgue, gpy_matern12, ProductMatern12GPy, QuadratureProductMatern12LebesgueMeasure
+    )
+
+
 # === Product Matern32 wrapper test cases
 @pytest.fixture
 def wrapper_matern32_1(dim2, gpy_prodmatern32):
@@ -175,6 +204,8 @@ gpy_test_list = [
     lazy_fixture("wrapper_rbf_2"),
     lazy_fixture("wrapper_brownian_1"),
     lazy_fixture("wrapper_brownian_2"),
+    lazy_fixture("wrapper_matern12_1"),
+    lazy_fixture("wrapper_matern12_2"),
     lazy_fixture("wrapper_matern32_1"),
     lazy_fixture("wrapper_matern32_2"),
     lazy_fixture("wrapper_matern52_1"),

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -10,11 +10,13 @@ import numpy as np
 from test_quadrature_kernels import (
     get_gaussian_qrbf,
     get_lebesgue_normalized_qbrownian,
+    get_lebesgue_normalized_qmatern12,
     get_lebesgue_normalized_qmatern32,
     get_lebesgue_normalized_qmatern52,
     get_lebesgue_normalized_qprodbrownian,
     get_lebesgue_normalized_qrbf,
     get_lebesgue_qbrownian,
+    get_lebesgue_qmatern12,
     get_lebesgue_qmatern32,
     get_lebesgue_qmatern52,
     get_lebesgue_qprodbrownian,
@@ -98,10 +100,11 @@ if __name__ == "__main__":
 
     # === Choose KERNEL BELOW ======
     # KERNEL = "rbf"
+    KERNEL = "matern12"
     # KERNEL = "matern32"
     # KERNEL = "matern52"
     # KERNEL = "brownian"
-    KERNEL = "prodbrownian"
+    # KERNEL = "prodbrownian"
     # === CHOOSE KERNEL ABOVE ======
 
     _e = "Kernel embedding not implemented."
@@ -112,6 +115,13 @@ if __name__ == "__main__":
             emukit_qkern, dat = get_lebesgue_qrbf()
         elif MEASURE == "Lebesgue-normalized":
             emukit_qkern, dat = get_lebesgue_normalized_qrbf()
+        else:
+            raise ValueError(_e)
+    elif KERNEL == "matern12":
+        if MEASURE == "Lebesgue":
+            emukit_qkern, dat = get_lebesgue_qmatern12()
+        elif MEASURE == "Lebesgue-normalized":
+            emukit_qkern, dat = get_lebesgue_normalized_qmatern12()
         else:
             raise ValueError(_e)
     elif KERNEL == "matern32":

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -305,7 +305,7 @@ lebesgue_embeddings_test_dict = {
     "qmatern32": lazy_fixture("lebesgue_qmatern32"),
     "qmatern52": lazy_fixture("lebesgue_qmatern52"),
     "qbrownian": lazy_fixture("lebesgue_qbrownian"),
-    "qprodbrownian": lazy_fixture("lebesgue_normalized_qprodbrownian"),
+    "qprodbrownian": lazy_fixture("lebesgue_qprodbrownian"),
 }
 
 lebesgue_normalized_embeddings_test_dict = {

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -253,7 +253,7 @@ def lebesgue_qbrownian():
 
 
 @pytest.fixture
-def lebesque_qprodbrownian():
+def lebesgue_qprodbrownian():
     qkern, dat = get_lebesgue_qprodbrownian()
     return qkern, dat.x1, dat.x2, dat.N, dat.M, dat.D, dat.dat_bounds
 
@@ -290,35 +290,37 @@ def lebesgue_normalized_qbrownian():
 
 
 @pytest.fixture
-def lebesque_normalized_qprodbrownian():
+def lebesgue_normalized_qprodbrownian():
     qkern, dat = get_lebesgue_normalized_qprodbrownian()
     return qkern, dat.x1, dat.x2, dat.N, dat.M, dat.D, dat.dat_bounds
 
 
-gaussian_embeddings_test_list = [
-    lazy_fixture("gaussian_qrbf"),
-]
+gaussian_embeddings_test_dict = {
+    "qrbf": lazy_fixture("gaussian_qrbf"),
+}
 
-lebesgue_embeddings_test_list = [
-    lazy_fixture("lebesgue_qrbf"),
-    lazy_fixture("lebesgue_qmatern12"),
-    lazy_fixture("lebesgue_qmatern32"),
-    lazy_fixture("lebesgue_qmatern52"),
-    lazy_fixture("lebesgue_qbrownian"),
-    lazy_fixture("lebesque_qprodbrownian"),
-]
+lebesgue_embeddings_test_dict = {
+    "qrbf": lazy_fixture("lebesgue_qrbf"),
+    "qmatern12": lazy_fixture("lebesgue_qmatern12"),
+    "qmatern32": lazy_fixture("lebesgue_qmatern32"),
+    "qmatern52": lazy_fixture("lebesgue_qmatern52"),
+    "qbrownian": lazy_fixture("lebesgue_qbrownian"),
+    "qprodbrownian": lazy_fixture("lebesgue_normalized_qprodbrownian"),
+}
 
-lebesgue_normalized_embeddings_test_list = [
-    lazy_fixture("lebesgue_normalized_qrbf"),
-    lazy_fixture("lebesgue_normalized_qmatern12"),
-    lazy_fixture("lebesgue_normalized_qmatern32"),
-    lazy_fixture("lebesgue_normalized_qmatern52"),
-    lazy_fixture("lebesgue_normalized_qbrownian"),
-    lazy_fixture("lebesque_normalized_qprodbrownian"),
-]
+lebesgue_normalized_embeddings_test_dict = {
+    "qrbf": lazy_fixture("lebesgue_normalized_qrbf"),
+    "qmatern12": lazy_fixture("lebesgue_normalized_qmatern12"),
+    "qmatern32": lazy_fixture("lebesgue_normalized_qmatern32"),
+    "qmatern52": lazy_fixture("lebesgue_normalized_qmatern52"),
+    "qbrownian": lazy_fixture("lebesgue_normalized_qbrownian"),
+    "qprodbrownian": lazy_fixture("lebesgue_normalized_qprodbrownian"),
+}
 
 embeddings_test_list = (
-    gaussian_embeddings_test_list + lebesgue_embeddings_test_list + lebesgue_normalized_embeddings_test_list
+    list(gaussian_embeddings_test_dict.values())
+    + list(lebesgue_embeddings_test_dict.values())
+    + list(lebesgue_normalized_embeddings_test_dict.values())
 )
 
 
@@ -342,19 +344,19 @@ def test_qkernel_shapes(kernel_embedding):
 @pytest.mark.parametrize(
     "kernel_embedding,interval",
     [
-        (gaussian_embeddings_test_list[0], [0.22019471616760106, 0.22056701590213823]),
-        (lebesgue_embeddings_test_list[0], [38.267217898004176, 38.32112525041843]),
-        (lebesgue_embeddings_test_list[1], [23.989038590657223, 24.018860660258476]),
-        (lebesgue_embeddings_test_list[2], [33.68147561344138, 33.72674814040212]),
-        (lebesgue_embeddings_test_list[3], [36.31179230918318, 36.36244064795965]),
-        (lebesgue_embeddings_test_list[4], [0.6527648875308305, 0.6539297075650101]),
-        (lebesgue_embeddings_test_list[5], [147.14888857464945, 147.3118404349691]),
-        (lebesgue_normalized_embeddings_test_list[0], [0.11810869721606222, 0.11827507793339022]),
-        (lebesgue_normalized_embeddings_test_list[1], [0.07404024256375687, 0.07413228598845208]),
-        (lebesgue_normalized_embeddings_test_list[2], [0.10395517164642398, 0.10409490166790775]),
-        (lebesgue_normalized_embeddings_test_list[3], [0.11207343305303447, 0.11222975508629518]),
-        (lebesgue_normalized_embeddings_test_list[4], [0.3330433099647094, 0.3336376059005152]),
-        (lebesgue_normalized_embeddings_test_list[5], [5.199166451419295, 5.204923979414083]),
+        (gaussian_embeddings_test_dict["qrbf"], [0.22019471616760106, 0.22056701590213823]),
+        (lebesgue_embeddings_test_dict["qrbf"], [38.267217898004176, 38.32112525041843]),
+        (lebesgue_embeddings_test_dict["qmatern12"], [23.989038590657223, 24.018860660258476]),
+        (lebesgue_embeddings_test_dict["qmatern32"], [33.68147561344138, 33.72674814040212]),
+        (lebesgue_embeddings_test_dict["qmatern52"], [36.31179230918318, 36.36244064795965]),
+        (lebesgue_embeddings_test_dict["qbrownian"], [0.6527648875308305, 0.6539297075650101]),
+        (lebesgue_embeddings_test_dict["qprodbrownian"], [147.14888857464945, 147.3118404349691]),
+        (lebesgue_normalized_embeddings_test_dict["qrbf"], [0.11810869721606222, 0.11827507793339022]),
+        (lebesgue_normalized_embeddings_test_dict["qmatern12"], [0.07404024256375687, 0.07413228598845208]),
+        (lebesgue_normalized_embeddings_test_dict["qmatern32"], [0.10395517164642398, 0.10409490166790775]),
+        (lebesgue_normalized_embeddings_test_dict["qmatern52"], [0.11207343305303447, 0.11222975508629518]),
+        (lebesgue_normalized_embeddings_test_dict["qbrownian"], [0.3330433099647094, 0.3336376059005152]),
+        (lebesgue_normalized_embeddings_test_dict["qprodbrownian"], [5.199166451419295, 5.204923979414083]),
     ],
 )
 def test_qkernel_qKq(kernel_embedding, interval):
@@ -372,7 +374,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
     "kernel_embedding,intervals",
     [
         (
-            gaussian_embeddings_test_list[0],
+            gaussian_embeddings_test_dict["qrbf"],
             np.array(
                 [
                     [0.13947611219369957, 0.14011691061322437],
@@ -383,7 +385,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_embeddings_test_list[0],
+            lebesgue_embeddings_test_dict["qrbf"],
             np.array(
                 [
                     [1.5229873955135163, 1.537991178335842],
@@ -394,7 +396,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_embeddings_test_list[1],
+            lebesgue_embeddings_test_dict["qmatern12"],
             np.array(
                 [
                     [0.8454460426328465, 0.8580996295972143],
@@ -405,7 +407,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_embeddings_test_list[2],
+            lebesgue_embeddings_test_dict["qmatern32"],
             np.array(
                 [
                     [1.1766117360187398, 1.1935736584098973],
@@ -416,7 +418,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_embeddings_test_list[3],
+            lebesgue_embeddings_test_dict["qmatern52"],
             np.array(
                 [
                     [1.26728433492353, 1.2866546055251578],
@@ -427,7 +429,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_embeddings_test_list[4],
+            lebesgue_embeddings_test_dict["qbrownian"],
             np.array(
                 [
                     [0.1743636401938356, 0.17438715306808195],
@@ -438,7 +440,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_embeddings_test_list[5],
+            lebesgue_embeddings_test_dict["qprodbrownian"],
             np.array(
                 [
                     [20.967420743471486, 20.980449036984133],
@@ -449,7 +451,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_normalized_embeddings_test_list[0],
+            lebesgue_normalized_embeddings_test_dict["qrbf"],
             np.array(
                 [
                     [0.08461041086186201, 0.08544395435199122],
@@ -460,7 +462,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_normalized_embeddings_test_list[1],
+            lebesgue_normalized_embeddings_test_dict["qmatern12"],
             np.array(
                 [
                     [0.04696922459071368, 0.04767220164428967],
@@ -471,7 +473,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_normalized_embeddings_test_list[2],
+            lebesgue_normalized_embeddings_test_dict["qmatern32"],
             np.array(
                 [
                     [0.06536731866770777, 0.06630964768943874],
@@ -482,7 +484,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_normalized_embeddings_test_list[3],
+            lebesgue_normalized_embeddings_test_dict["qmatern52"],
             np.array(
                 [
                     [0.07040468527352946, 0.07148081141806432],
@@ -493,7 +495,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_normalized_embeddings_test_list[4],
+            lebesgue_normalized_embeddings_test_dict["qbrownian"],
             np.array(
                 [
                     [0.12454545728131114, 0.12456225219148712],
@@ -504,7 +506,7 @@ def test_qkernel_qKq(kernel_embedding, interval):
             ),
         ),
         (
-            lebesgue_normalized_embeddings_test_list[5],
+            lebesgue_normalized_embeddings_test_dict["qprodbrownian"],
             np.array(
                 [
                     [3.9412445006525356, 3.9436934280045364],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds

- kernel embeddings for the Matern12 (a.k.a. Exponential) product kernel w.r.t. Lebesgue measure.
- an EmuKit interface for this kernel.
- a GPy wrapper for said interface.
- the kernel is added to the tests (shape, value, gradient etc tests) by adding a fixture to the existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
