### PR TITLE
Fix scipy again

### DIFF
--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -113,13 +113,9 @@ def _estimate_lipschitz_constant(space: ParameterSpace, model: IDifferentiable):
     samples = space.sample_uniform(N_SAMPLES)
     samples = np.vstack([samples, model.X])
     gradient_norm_at_samples = negative_gradient_norm(samples)
-    # x0 = samples[np.argmin(gradient_norm_at_samples)][None, :]
     x0 = samples[np.argmin(gradient_norm_at_samples)]
 
     # Run optimizer to find point of highest gradient
-    print('#####################################')
-    print("pre x0", samples[np.argmin(gradient_norm_at_samples)])
-    print("x0: ", x0)
     res = scipy.optimize.minimize(
         lambda x: negative_gradient_norm(x[None, :]), x0, bounds=space.get_bounds(), options={"maxiter": MAX_ITER}
     )

--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -113,9 +113,13 @@ def _estimate_lipschitz_constant(space: ParameterSpace, model: IDifferentiable):
     samples = space.sample_uniform(N_SAMPLES)
     samples = np.vstack([samples, model.X])
     gradient_norm_at_samples = negative_gradient_norm(samples)
-    x0 = samples[np.argmin(gradient_norm_at_samples)][None, :]
+    # x0 = samples[np.argmin(gradient_norm_at_samples)][None, :]
+    x0 = samples[np.argmin(gradient_norm_at_samples)]
 
     # Run optimizer to find point of highest gradient
+    print('#####################################')
+    print("pre x0", samples[np.argmin(gradient_norm_at_samples)])
+    print("x0: ", x0)
     res = scipy.optimize.minimize(
         lambda x: negative_gradient_norm(x[None, :]), x0, bounds=space.get_bounds(), options={"maxiter": MAX_ITER}
     )


### PR DESCRIPTION
*Issue #, if available:* #421

*Description of changes:* Scipy minimize expects 1d inputs, and we were passing 2d for some unclear reason. Best part is that we were doing it intentionally, for no other reason, so the fix is just to remove a few symbols. Nice!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
