### PR TITLE
Fixing numpy seed in flaky test

### DIFF
--- a/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
@@ -8,6 +8,7 @@ from emukit.test_functions import branin_function
 
 
 def test_optimization_with_linear_constraint():
+    np.random.seed(0)
     branin_fcn, parameter_space = branin_function()
     x_init = parameter_space.sample_uniform(10)
     y_init = branin_fcn(x_init)

--- a/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
@@ -8,6 +8,7 @@ from emukit.test_functions import branin_function
 
 
 def test_optimization_with_linear_constraint():
+    # Fixing the numpy seed stops flakiness (see https://github.com/EmuKit/emukit/issues/421)
     np.random.seed(0)
     branin_fcn, parameter_space = branin_function()
     x_init = parameter_space.sample_uniform(10)


### PR DESCRIPTION
*Issue #421 , if available:* 

*Description of changes:*
This PR sets a fixed numpy.random.seed for the flaky test mentioned in the issue. It seems to stop the flakiness. 

Still not entirely sure why it is flaky but it might be related to hyper-param optimization. In all the failed tests that I checked the lengthscale of the GP was very tiny for some reason (1e-300).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
