### PR TITLE
Add a Dependabot config to autoupdate GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

I noticed when reviewing recent CI runs that there were deprecation warnings due to out-of-date GitHub action versions (like `actions/checkout@v2`) [[recent example](https://github.com/EmuKit/emukit/actions/runs/5063833404)].

Rather than update the action versions just one time, this PR introduces a Dependabot configuration that will make GitHub's Dependabot automatically submit PRs to keep the actions up-to-date. This should reduce maintenance burden.

If this merges, you should see Dependabot open PRs pretty quickly to address the out-of-date action versions.

I read the contributing guidelines and I think I followed them, but please let me know if there's anything I missed that needs to be addressed. Thanks!

See you at SciPy 2023!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
