### PR TITLE
Fixed typo in multi-fidelity test function Currin

### DIFF
--- a/emukit/test_functions/multi_fidelity/currin.py
+++ b/emukit/test_functions/multi_fidelity/currin.py
@@ -33,8 +33,7 @@ def multi_fidelity_currin_function() -> Tuple[MultiSourceFunctionWrapper, Parame
         x1 = x[:, 0]
         x2 = x[:, 1]
         return (
-            1
-            - np.exp(-0.5 / x2)
+            (1 - np.exp(-0.5 / x2))
             * ((2300 * x1**3 + 1900 * x1**2 + 2092 * x1 + 60) / (100 * x1**3 + 500 * x1**2 + 4 * x1 + 20))
         )[:, None]
 


### PR DESCRIPTION
*Issue #450*

*Description of changes:* Fixed typo in multi-fidelity test function Currin according to https://www.sfu.ca/~ssurjano/curretal91.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.