### PR TITLE
Update copyright headers

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,3 @@
 Emukit
-Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright 2024 The Emukit Authors. All Rights Reserved.
+Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,3 @@
 Emukit
-Copyright 2024 The Emukit Authors. All Rights Reserved.
-Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
+Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License").

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,19 +1,9 @@
 # Copyright 2024 The Emukit Authors. All Rights Reserved.
-#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License").
-#   You may not use this file except in compliance with the License.
-#   A copy of the License is located at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   or in the "license" file accompanying this file. This file is distributed
-#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-#   express or implied. See the License for the specific language governing
-#   permissions and limitations under the License.
-# ==============================================================================
-# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: Apache-2.0
+
 
 from datetime import datetime
 import os
@@ -21,7 +11,7 @@ import shutil
 import sys
 from os.path import abspath, dirname
 
-# -- Mock graphing modules - workaround for optinal dependencies as well as for wrong behavior of some required ones
+# -- Mock graphing modules - workaround for optional dependencies as well as for wrong behavior of some required ones
 from unittest.mock import MagicMock
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,11 +1,6 @@
 # Copyright 2024 The Emukit Authors. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
+#
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
-
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License").
 #   You may not use this file except in compliance with the License.

--- a/emukit/__init__.py
+++ b/emukit/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/__init__.py
+++ b/emukit/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from emukit.__version__ import __version__

--- a/emukit/__version__.py
+++ b/emukit/__version__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/__version__.py
+++ b/emukit/__version__.py
@@ -1,4 +1,6 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+#
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License").
 #   You may not use this file except in compliance with the License.

--- a/emukit/__version__.py
+++ b/emukit/__version__.py
@@ -1,16 +1,8 @@
 # Copyright 2024 The Emukit Authors. All Rights Reserved.
-#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License").
-#   You may not use this file except in compliance with the License.
-#   A copy of the License is located at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   or in the "license" file accompanying this file. This file is distributed
-#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-#   express or implied. See the License for the specific language governing
-#   permissions and limitations under the License.
-# ==============================================================================
+# SPDX-License-Identifier: Apache-2.0
+
+
 __version__ = "0.4.10"  # noqa

--- a/emukit/bayesian_optimization/__init__.py
+++ b/emukit/bayesian_optimization/__init__.py
@@ -1,2 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/bayesian_optimization/__init__.py
+++ b/emukit/bayesian_optimization/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/bayesian_optimization/__init__.py
+++ b/emukit/bayesian_optimization/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/bayesian_optimization/acquisitions/__init__.py
+++ b/emukit/bayesian_optimization/acquisitions/__init__.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 # there are circular imports in this package, hence we can't just sort alphabetically
 # isort: skip_file

--- a/emukit/bayesian_optimization/acquisitions/__init__.py
+++ b/emukit/bayesian_optimization/acquisitions/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/entropy_search.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/entropy_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/expected_improvement.py
+++ b/emukit/bayesian_optimization/acquisitions/expected_improvement.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/expected_improvement.py
+++ b/emukit/bayesian_optimization/acquisitions/expected_improvement.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/local_penalization.py
+++ b/emukit/bayesian_optimization/acquisitions/local_penalization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/local_penalization.py
+++ b/emukit/bayesian_optimization/acquisitions/local_penalization.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/bayesian_optimization/acquisitions/log_acquisition.py
+++ b/emukit/bayesian_optimization/acquisitions/log_acquisition.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/log_acquisition.py
+++ b/emukit/bayesian_optimization/acquisitions/log_acquisition.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/bayesian_optimization/acquisitions/max_value_entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/max_value_entropy_search.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/max_value_entropy_search.py
+++ b/emukit/bayesian_optimization/acquisitions/max_value_entropy_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/negative_lower_confidence_bound.py
+++ b/emukit/bayesian_optimization/acquisitions/negative_lower_confidence_bound.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/negative_lower_confidence_bound.py
+++ b/emukit/bayesian_optimization/acquisitions/negative_lower_confidence_bound.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/probability_of_feasibility.py
+++ b/emukit/bayesian_optimization/acquisitions/probability_of_feasibility.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/probability_of_feasibility.py
+++ b/emukit/bayesian_optimization/acquisitions/probability_of_feasibility.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/probability_of_improvement.py
+++ b/emukit/bayesian_optimization/acquisitions/probability_of_improvement.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/acquisitions/probability_of_improvement.py
+++ b/emukit/bayesian_optimization/acquisitions/probability_of_improvement.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/epmgp.py
+++ b/emukit/bayesian_optimization/epmgp.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/epmgp.py
+++ b/emukit/bayesian_optimization/epmgp.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/interfaces/__init__.py
+++ b/emukit/bayesian_optimization/interfaces/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/interfaces/__init__.py
+++ b/emukit/bayesian_optimization/interfaces/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/interfaces/models.py
+++ b/emukit/bayesian_optimization/interfaces/models.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/interfaces/models.py
+++ b/emukit/bayesian_optimization/interfaces/models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Optional
 
 import numpy as np

--- a/emukit/bayesian_optimization/local_penalization_calculator.py
+++ b/emukit/bayesian_optimization/local_penalization_calculator.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/__init__.py
+++ b/emukit/bayesian_optimization/loops/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/__init__.py
+++ b/emukit/bayesian_optimization/loops/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/bayesian_optimization_loop.py
+++ b/emukit/bayesian_optimization/loops/bayesian_optimization_loop.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/bayesian_optimization_loop.py
+++ b/emukit/bayesian_optimization/loops/bayesian_optimization_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/cost_sensitive_bayesian_optimization_loop.py
+++ b/emukit/bayesian_optimization/loops/cost_sensitive_bayesian_optimization_loop.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/cost_sensitive_bayesian_optimization_loop.py
+++ b/emukit/bayesian_optimization/loops/cost_sensitive_bayesian_optimization_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/unknown_constraint_bayesian_optimization_loop.py
+++ b/emukit/bayesian_optimization/loops/unknown_constraint_bayesian_optimization_loop.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/bayesian_optimization/loops/unknown_constraint_bayesian_optimization_loop.py
+++ b/emukit/bayesian_optimization/loops/unknown_constraint_bayesian_optimization_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/benchmarking/__init__.py
+++ b/emukit/benchmarking/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/benchmarking/__init__.py
+++ b/emukit/benchmarking/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/benchmarking/__init__.py
+++ b/emukit/benchmarking/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/benchmarking/loop_benchmarking/__init__.py
+++ b/emukit/benchmarking/loop_benchmarking/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/benchmarking/loop_benchmarking/__init__.py
+++ b/emukit/benchmarking/loop_benchmarking/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/benchmarking/loop_benchmarking/__init__.py
+++ b/emukit/benchmarking/loop_benchmarking/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from itertools import cycle
 from typing import List
 

--- a/emukit/benchmarking/loop_benchmarking/benchmark_result.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_result.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import List
 
 import numpy as np

--- a/emukit/benchmarking/loop_benchmarking/benchmark_result.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_result.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/benchmarking/loop_benchmarking/benchmarker.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmarker.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/benchmarking/loop_benchmarking/benchmarker.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmarker.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import logging
 from functools import partial
 from typing import Callable, List, Tuple, Union

--- a/emukit/benchmarking/loop_benchmarking/metrics.py
+++ b/emukit/benchmarking/loop_benchmarking/metrics.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from time import time
 
 import numpy as np

--- a/emukit/benchmarking/loop_benchmarking/metrics.py
+++ b/emukit/benchmarking/loop_benchmarking/metrics.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/benchmarking/loop_benchmarking/random_search.py
+++ b/emukit/benchmarking/loop_benchmarking/random_search.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import numpy as np
 

--- a/emukit/benchmarking/loop_benchmarking/random_search.py
+++ b/emukit/benchmarking/loop_benchmarking/random_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/__init__.py
+++ b/emukit/core/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/__init__.py
+++ b/emukit/core/__init__.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from .bandit_parameter import BanditParameter  # noqa: F401
 from .categorical_parameter import CategoricalParameter  # noqa: F401

--- a/emukit/core/acquisition/__init__.py
+++ b/emukit/core/acquisition/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/acquisition/__init__.py
+++ b/emukit/core/acquisition/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/acquisition/acquisition.py
+++ b/emukit/core/acquisition/acquisition.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/acquisition/acquisition.py
+++ b/emukit/core/acquisition/acquisition.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/acquisition/acquisition_per_cost.py
+++ b/emukit/core/acquisition/acquisition_per_cost.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/acquisition/acquisition_per_cost.py
+++ b/emukit/core/acquisition/acquisition_per_cost.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/core/acquisition/integrated_acquisition.py
+++ b/emukit/core/acquisition/integrated_acquisition.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/acquisition/integrated_acquisition.py
+++ b/emukit/core/acquisition/integrated_acquisition.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Callable, Tuple, Union
 
 import numpy as np

--- a/emukit/core/bandit_parameter.py
+++ b/emukit/core/bandit_parameter.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2020 Opsani, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/emukit/core/bandit_parameter.py
+++ b/emukit/core/bandit_parameter.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/categorical_parameter.py
+++ b/emukit/core/categorical_parameter.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/categorical_parameter.py
+++ b/emukit/core/categorical_parameter.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/constraints.py
+++ b/emukit/core/constraints.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import logging
 from typing import Callable, Optional
 

--- a/emukit/core/constraints.py
+++ b/emukit/core/constraints.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/continuous_parameter.py
+++ b/emukit/core/continuous_parameter.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/continuous_parameter.py
+++ b/emukit/core/continuous_parameter.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/discrete_parameter.py
+++ b/emukit/core/discrete_parameter.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/discrete_parameter.py
+++ b/emukit/core/discrete_parameter.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/encodings.py
+++ b/emukit/core/encodings.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/encodings.py
+++ b/emukit/core/encodings.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/event_handler.py
+++ b/emukit/core/event_handler.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 class EventHandler(list):
     """
     A list of callable objects. Calling an instance of this will cause a call to each item in the list in ascending

--- a/emukit/core/event_handler.py
+++ b/emukit/core/event_handler.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/initial_designs/__init__.py
+++ b/emukit/core/initial_designs/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/initial_designs/__init__.py
+++ b/emukit/core/initial_designs/__init__.py
@@ -1,4 +1,8 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from .random_design import RandomDesign  # noqa: F401

--- a/emukit/core/initial_designs/base.py
+++ b/emukit/core/initial_designs/base.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import numpy as np
 

--- a/emukit/core/initial_designs/base.py
+++ b/emukit/core/initial_designs/base.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/initial_designs/latin_design.py
+++ b/emukit/core/initial_designs/latin_design.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/initial_designs/latin_design.py
+++ b/emukit/core/initial_designs/latin_design.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/initial_designs/random_design.py
+++ b/emukit/core/initial_designs/random_design.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import numpy as np
 

--- a/emukit/core/initial_designs/random_design.py
+++ b/emukit/core/initial_designs/random_design.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/initial_designs/sobol_design.py
+++ b/emukit/core/initial_designs/sobol_design.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/emukit/core/initial_designs/sobol_design.py
+++ b/emukit/core/initial_designs/sobol_design.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/interfaces/__init__.py
+++ b/emukit/core/interfaces/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/interfaces/__init__.py
+++ b/emukit/core/interfaces/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/interfaces/models.py
+++ b/emukit/core/interfaces/models.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/interfaces/models.py
+++ b/emukit/core/interfaces/models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/__init__.py
+++ b/emukit/core/loop/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/__init__.py
+++ b/emukit/core/loop/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/candidate_point_calculators.py
+++ b/emukit/core/loop/candidate_point_calculators.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/candidate_point_calculators.py
+++ b/emukit/core/loop/candidate_point_calculators.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/loop_state.py
+++ b/emukit/core/loop/loop_state.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/loop_state.py
+++ b/emukit/core/loop/loop_state.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/model_updaters.py
+++ b/emukit/core/loop/model_updaters.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/model_updaters.py
+++ b/emukit/core/loop/model_updaters.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/stopping_conditions.py
+++ b/emukit/core/loop/stopping_conditions.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/stopping_conditions.py
+++ b/emukit/core/loop/stopping_conditions.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/user_function.py
+++ b/emukit/core/loop/user_function.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/user_function.py
+++ b/emukit/core/loop/user_function.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/user_function_result.py
+++ b/emukit/core/loop/user_function_result.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/loop/user_function_result.py
+++ b/emukit/core/loop/user_function_result.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/__init__.py
+++ b/emukit/core/optimization/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/__init__.py
+++ b/emukit/core/optimization/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/acquisition_optimizer.py
+++ b/emukit/core/optimization/acquisition_optimizer.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import abc
 from typing import Optional, Tuple

--- a/emukit/core/optimization/anchor_points_generator.py
+++ b/emukit/core/optimization/anchor_points_generator.py
@@ -1,5 +1,10 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import logging
 
 import numpy as np

--- a/emukit/core/optimization/anchor_points_generator.py
+++ b/emukit/core/optimization/anchor_points_generator.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/context_manager.py
+++ b/emukit/core/optimization/context_manager.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/context_manager.py
+++ b/emukit/core/optimization/context_manager.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import logging
 from typing import Any, Dict

--- a/emukit/core/optimization/gradient_acquisition_optimizer.py
+++ b/emukit/core/optimization/gradient_acquisition_optimizer.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import logging
 from typing import Tuple

--- a/emukit/core/optimization/gradient_acquisition_optimizer.py
+++ b/emukit/core/optimization/gradient_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/local_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/local_search_acquisition_optimizer.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import logging
 from typing import List, Optional, Sequence, Tuple

--- a/emukit/core/optimization/local_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/local_search_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/multi_source_acquisition_optimizer.py
+++ b/emukit/core/optimization/multi_source_acquisition_optimizer.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/multi_source_acquisition_optimizer.py
+++ b/emukit/core/optimization/multi_source_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/optimizer.py
+++ b/emukit/core/optimization/optimizer.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from typing import Callable, List, Tuple
 

--- a/emukit/core/optimization/optimizer.py
+++ b/emukit/core/optimization/optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/optimization/random_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/random_search_acquisition_optimizer.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import logging
 from typing import Tuple

--- a/emukit/core/optimization/random_search_acquisition_optimizer.py
+++ b/emukit/core/optimization/random_search_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/parameter.py
+++ b/emukit/core/parameter.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/parameter.py
+++ b/emukit/core/parameter.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/core/parameter_space.py
+++ b/emukit/core/parameter_space.py
@@ -1,5 +1,10 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import itertools
 from typing import List, Optional, Tuple
 

--- a/emukit/core/parameter_space.py
+++ b/emukit/core/parameter_space.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/__init__.py
+++ b/emukit/examples/__init__.py
@@ -1,2 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/examples/__init__.py
+++ b/emukit/examples/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/__init__.py
+++ b/emukit/examples/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/dynamic_negative_lower_confidence_bound/__init__.py
+++ b/emukit/examples/dynamic_negative_lower_confidence_bound/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/dynamic_negative_lower_confidence_bound/__init__.py
+++ b/emukit/examples/dynamic_negative_lower_confidence_bound/__init__.py
@@ -1,1 +1,5 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .dnlcb import DynamicNegativeLowerConfidenceBound

--- a/emukit/examples/dynamic_negative_lower_confidence_bound/dnlcb.py
+++ b/emukit/examples/dynamic_negative_lower_confidence_bound/dnlcb.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/dynamic_negative_lower_confidence_bound/dnlcb.py
+++ b/emukit/examples/dynamic_negative_lower_confidence_bound/dnlcb.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Union
 
 import numpy as np

--- a/emukit/examples/emulation_mountain_car_simulator/mountain_car.py
+++ b/emukit/examples/emulation_mountain_car_simulator/mountain_car.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/emulation_mountain_car_simulator/mountain_car.py
+++ b/emukit/examples/emulation_mountain_car_simulator/mountain_car.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import matplotlib.pyplot as plt
 import numpy as np
 from IPython.display import display

--- a/emukit/examples/fabolas/__init__.py
+++ b/emukit/examples/fabolas/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/fabolas/__init__.py
+++ b/emukit/examples/fabolas/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .fabolas_loop import FabolasLoop
 from .fabolas_model import FabolasModel
 from .fmin import fmin_fabolas

--- a/emukit/examples/fabolas/continuous_fidelity_entropy_search.py
+++ b/emukit/examples/fabolas/continuous_fidelity_entropy_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/fabolas/continuous_fidelity_entropy_search.py
+++ b/emukit/examples/fabolas/continuous_fidelity_entropy_search.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Union
 
 import numpy as np

--- a/emukit/examples/fabolas/example.py
+++ b/emukit/examples/fabolas/example.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """
 This file implements an example of how to use Fabolas via the provided fmin interface to optimize the
 hyperparameters of a SVM.

--- a/emukit/examples/fabolas/example.py
+++ b/emukit/examples/fabolas/example.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/fabolas/fabolas_loop.py
+++ b/emukit/examples/fabolas/fabolas_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/fabolas/fabolas_loop.py
+++ b/emukit/examples/fabolas/fabolas_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.bayesian_optimization.loops.cost_sensitive_bayesian_optimization_loop import (

--- a/emukit/examples/fabolas/fabolas_model.py
+++ b/emukit/examples/fabolas/fabolas_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/fabolas/fabolas_model.py
+++ b/emukit/examples/fabolas/fabolas_model.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from copy import deepcopy
 from typing import Tuple
 

--- a/emukit/examples/fabolas/fmin.py
+++ b/emukit/examples/fabolas/fmin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/fabolas/fmin.py
+++ b/emukit/examples/fabolas/fmin.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.core.initial_designs.latin_design import LatinDesign

--- a/emukit/examples/gp_bayesian_optimization/__init__.py
+++ b/emukit/examples/gp_bayesian_optimization/__init__.py
@@ -1,2 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/examples/gp_bayesian_optimization/__init__.py
+++ b/emukit/examples/gp_bayesian_optimization/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/gp_bayesian_optimization/__init__.py
+++ b/emukit/examples/gp_bayesian_optimization/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/gp_bayesian_optimization/enums.py
+++ b/emukit/examples/gp_bayesian_optimization/enums.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from enum import Enum
 
 

--- a/emukit/examples/gp_bayesian_optimization/enums.py
+++ b/emukit/examples/gp_bayesian_optimization/enums.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/gp_bayesian_optimization/optimization_loops.py
+++ b/emukit/examples/gp_bayesian_optimization/optimization_loops.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/gp_bayesian_optimization/optimization_loops.py
+++ b/emukit/examples/gp_bayesian_optimization/optimization_loops.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from ...bayesian_optimization.acquisitions import (

--- a/emukit/examples/gp_bayesian_optimization/single_objective_bayesian_optimization.py
+++ b/emukit/examples/gp_bayesian_optimization/single_objective_bayesian_optimization.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/gp_bayesian_optimization/single_objective_bayesian_optimization.py
+++ b/emukit/examples/gp_bayesian_optimization/single_objective_bayesian_optimization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/gp_bayesian_optimization/unknown_constraint_bayesian_optimization.py
+++ b/emukit/examples/gp_bayesian_optimization/unknown_constraint_bayesian_optimization.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/gp_bayesian_optimization/unknown_constraint_bayesian_optimization.py
+++ b/emukit/examples/gp_bayesian_optimization/unknown_constraint_bayesian_optimization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/models/__init__.py
+++ b/emukit/examples/models/__init__.py
@@ -1,2 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/examples/models/__init__.py
+++ b/emukit/examples/models/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/models/__init__.py
+++ b/emukit/examples/models/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/models/bohamiann.py
+++ b/emukit/examples/models/bohamiann.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import numpy as np
 

--- a/emukit/examples/models/bohamiann.py
+++ b/emukit/examples/models/bohamiann.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/models/random_forest.py
+++ b/emukit/examples/models/random_forest.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import numpy as np
 

--- a/emukit/examples/models/random_forest.py
+++ b/emukit/examples/models/random_forest.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/multi_fidelity_dgp/__init__.py
+++ b/emukit/examples/multi_fidelity_dgp/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/examples/multi_fidelity_dgp/__init__.py
+++ b/emukit/examples/multi_fidelity_dgp/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/multi_fidelity_dgp/__init__.py
+++ b/emukit/examples/multi_fidelity_dgp/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/multi_fidelity_dgp/baseline_model_wrappers.py
+++ b/emukit/examples/multi_fidelity_dgp/baseline_model_wrappers.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """
 These are emukit model wrappers that contain the specific optimization procedures we found worked well for each model.
 

--- a/emukit/examples/multi_fidelity_dgp/baseline_model_wrappers.py
+++ b/emukit/examples/multi_fidelity_dgp/baseline_model_wrappers.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/multi_fidelity_dgp/multi_fidelity_deep_gp.py
+++ b/emukit/examples/multi_fidelity_dgp/multi_fidelity_deep_gp.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/multi_fidelity_dgp/multi_fidelity_deep_gp.py
+++ b/emukit/examples/multi_fidelity_dgp/multi_fidelity_deep_gp.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """
 This file contains the multi-fidelity deep Gaussian process model from:
 Deep Gaussian Processes for Multi-fidelity Modeling (Kurt Cutajar, Mark Pullin, Andreas Damianou, Neil Lawrence, Javier González)

--- a/emukit/examples/preferential_batch_bayesian_optimization/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/__init__.py
@@ -1,1 +1,4 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/__init__.py
@@ -1,4 +1,2 @@
 # Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/preferential_batch_bayesian_optimization/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/preferential_batch_bayesian_optimization/minimum_working_example.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/minimum_working_example.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import evalset.test_funcs
 import GPy
 from pbbo import *

--- a/emukit/examples/preferential_batch_bayesian_optimization/minimum_working_example.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/minimum_working_example.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # from .bayesian_optimization import *
 from .acquisitions import *
 from .bayesian_optimization import *

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .acquisition_function import *
 from .expectation_acquisition import *
 from .thompson_sampling_acquisition import *

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/acquisition_function.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/acquisition_function.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Callable, Dict, Optional, Tuple
 
 import numpy as np

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/acquisition_function.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/acquisition_function.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/expectation_acquisition.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/expectation_acquisition.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/expectation_acquisition.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/expectation_acquisition.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import collections
 import math
 import time

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/thompson_sampling_acquisition.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/thompson_sampling_acquisition.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import collections
 import time
 from typing import Callable, Dict, List, Tuple

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/thompson_sampling_acquisition.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/acquisitions/thompson_sampling_acquisition.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/bayesian_optimization.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/bayesian_optimization.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import logging
 import math
 from functools import partial

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/bayesian_optimization.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/bayesian_optimization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/gp_models.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/gp_models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/gp_models.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/gp_models.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import itertools
 import os
 import traceback

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .ep_batch_comparison import *
 from .mcmc_batch_comparison import *
 from .vi_batch_comparison import *

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/__init__.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/ep_batch_comparison.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/ep_batch_comparison.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import time
 from typing import Callable, Dict, List, Tuple
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/ep_batch_comparison.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/ep_batch_comparison.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/mcmc_batch_comparison.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/mcmc_batch_comparison.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import itertools
 import os
 import sys

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/mcmc_batch_comparison.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/mcmc_batch_comparison.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/vi_batch_comparison.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/vi_batch_comparison.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Callable, Dict, List, Tuple
 
 import GPy

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/vi_batch_comparison.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/inferences/vi_batch_comparison.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/util.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/util.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import logging
 from typing import Callable, Dict, List, Tuple
 

--- a/emukit/examples/preferential_batch_bayesian_optimization/pbbo/util.py
+++ b/emukit/examples/preferential_batch_bayesian_optimization/pbbo/util.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/__init__.py
+++ b/emukit/examples/profet/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/examples/profet/__init__.py
+++ b/emukit/examples/profet/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/profet/__init__.py
+++ b/emukit/examples/profet/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/profet/meta_benchmarks/__init__.py
+++ b/emukit/examples/profet/meta_benchmarks/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/meta_benchmarks/__init__.py
+++ b/emukit/examples/profet/meta_benchmarks/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .meta_fcnet import meta_fcnet
 from .meta_forrester import meta_forrester
 from .meta_svm import meta_svm

--- a/emukit/examples/profet/meta_benchmarks/architecture.py
+++ b/emukit/examples/profet/meta_benchmarks/architecture.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 try:
     import torch
     import torch.nn as nn

--- a/emukit/examples/profet/meta_benchmarks/architecture.py
+++ b/emukit/examples/profet/meta_benchmarks/architecture.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/meta_benchmarks/meta_fcnet.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_fcnet.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import pickle
 
 try:

--- a/emukit/examples/profet/meta_benchmarks/meta_fcnet.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_fcnet.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/meta_benchmarks/meta_forrester.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_forrester.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/meta_benchmarks/meta_forrester.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_forrester.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import pickle
 from functools import partial
 from typing import Tuple

--- a/emukit/examples/profet/meta_benchmarks/meta_surrogates.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_surrogates.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import torch
 

--- a/emukit/examples/profet/meta_benchmarks/meta_surrogates.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_surrogates.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/meta_benchmarks/meta_svm.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_svm.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import pickle
 
 try:

--- a/emukit/examples/profet/meta_benchmarks/meta_svm.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_svm.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/meta_benchmarks/meta_xgboost.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_xgboost.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import pickle
 
 try:

--- a/emukit/examples/profet/meta_benchmarks/meta_xgboost.py
+++ b/emukit/examples/profet/meta_benchmarks/meta_xgboost.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/performance_assessment.py
+++ b/emukit/examples/profet/performance_assessment.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/performance_assessment.py
+++ b/emukit/examples/profet/performance_assessment.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import scipy.stats as stats
 

--- a/emukit/examples/profet/train_meta_model.py
+++ b/emukit/examples/profet/train_meta_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/profet/train_meta_model.py
+++ b/emukit/examples/profet/train_meta_model.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import argparse
 import functools
 import json

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/__init__.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/__init__.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/base_models.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/base_models.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/base_models.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/base_models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_analysis.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_analysis.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_analysis.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_analysis.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_base.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_base.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_base.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/gillespie_base.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/seir_gillespie.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/seir_gillespie.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/seir_gillespie.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/seir_gillespie.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/sir_gillespie.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/sir_gillespie.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/sir_gillespie.py
+++ b/emukit/examples/spread_of_disease-with_seir_model/Emukit_task_seir_model/sir_gillespie.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/vanilla_bayesian_quadrature_with_rbf/__init__.py
+++ b/emukit/examples/vanilla_bayesian_quadrature_with_rbf/__init__.py
@@ -1,2 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/examples/vanilla_bayesian_quadrature_with_rbf/__init__.py
+++ b/emukit/examples/vanilla_bayesian_quadrature_with_rbf/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/examples/vanilla_bayesian_quadrature_with_rbf/__init__.py
+++ b/emukit/examples/vanilla_bayesian_quadrature_with_rbf/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/examples/vanilla_bayesian_quadrature_with_rbf/vanilla_bq_loop_with_rbf.py
+++ b/emukit/examples/vanilla_bayesian_quadrature_with_rbf/vanilla_bq_loop_with_rbf.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/examples/vanilla_bayesian_quadrature_with_rbf/vanilla_bq_loop_with_rbf.py
+++ b/emukit/examples/vanilla_bayesian_quadrature_with_rbf/vanilla_bq_loop_with_rbf.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/__init__.py
+++ b/emukit/experimental_design/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/__init__.py
+++ b/emukit/experimental_design/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/acquisitions/__init__.py
+++ b/emukit/experimental_design/acquisitions/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/acquisitions/__init__.py
+++ b/emukit/experimental_design/acquisitions/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/acquisitions/integrated_variance.py
+++ b/emukit/experimental_design/acquisitions/integrated_variance.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/acquisitions/integrated_variance.py
+++ b/emukit/experimental_design/acquisitions/integrated_variance.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/acquisitions/model_variance.py
+++ b/emukit/experimental_design/acquisitions/model_variance.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/acquisitions/model_variance.py
+++ b/emukit/experimental_design/acquisitions/model_variance.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/experimental_design_loop.py
+++ b/emukit/experimental_design/experimental_design_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/experimental_design_loop.py
+++ b/emukit/experimental_design/experimental_design_loop.py
@@ -1,5 +1,10 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from ..core.acquisition import Acquisition
 from ..core.interfaces.models import IModel
 from ..core.loop import FixedIntervalUpdater, OuterLoop, SequentialPointCalculator

--- a/emukit/experimental_design/interfaces/__init__.py
+++ b/emukit/experimental_design/interfaces/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/interfaces/__init__.py
+++ b/emukit/experimental_design/interfaces/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/interfaces/models.py
+++ b/emukit/experimental_design/interfaces/models.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/experimental_design/interfaces/models.py
+++ b/emukit/experimental_design/interfaces/models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/__init__.py
+++ b/emukit/model_wrappers/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/__init__.py
+++ b/emukit/model_wrappers/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/gpy_model_wrappers.py
+++ b/emukit/model_wrappers/gpy_model_wrappers.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/gpy_quadrature_wrappers.py
+++ b/emukit/model_wrappers/gpy_quadrature_wrappers.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """GPy wrappers for the quadrature package."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/model_wrappers/simple_gp_model.py
+++ b/emukit/model_wrappers/simple_gp_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/model_wrappers/simple_gp_model.py
+++ b/emukit/model_wrappers/simple_gp_model.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/model_wrappers/sklearn_model_wrapper.py
+++ b/emukit/model_wrappers/sklearn_model_wrapper.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/model_wrappers/sklearn_model_wrapper.py
+++ b/emukit/model_wrappers/sklearn_model_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/__init__.py
+++ b/emukit/multi_fidelity/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/__init__.py
+++ b/emukit/multi_fidelity/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/convert_lists_to_array.py
+++ b/emukit/multi_fidelity/convert_lists_to_array.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/convert_lists_to_array.py
+++ b/emukit/multi_fidelity/convert_lists_to_array.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/kernels/__init__.py
+++ b/emukit/multi_fidelity/kernels/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/kernels/__init__.py
+++ b/emukit/multi_fidelity/kernels/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/kernels/linear_multi_fidelity_kernel.py
+++ b/emukit/multi_fidelity/kernels/linear_multi_fidelity_kernel.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/kernels/linear_multi_fidelity_kernel.py
+++ b/emukit/multi_fidelity/kernels/linear_multi_fidelity_kernel.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/models/__init__.py
+++ b/emukit/multi_fidelity/models/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/models/__init__.py
+++ b/emukit/multi_fidelity/models/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/models/linear_model.py
+++ b/emukit/multi_fidelity/models/linear_model.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/models/linear_model.py
+++ b/emukit/multi_fidelity/models/linear_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
+++ b/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
+++ b/emukit/multi_fidelity/models/non_linear_multi_fidelity_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/__init__.py
+++ b/emukit/quadrature/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """This package contains solvers for numerical integration."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/__init__.py
+++ b/emukit/quadrature/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/__init__.py
+++ b/emukit/quadrature/acquisitions/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Acquisition functions for the quadrature package."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/acquisitions/__init__.py
+++ b/emukit/quadrature/acquisitions/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/mutual_information.py
+++ b/emukit/quadrature/acquisitions/mutual_information.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/mutual_information.py
+++ b/emukit/quadrature/acquisitions/mutual_information.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/squared_correlation.py
+++ b/emukit/quadrature/acquisitions/squared_correlation.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/squared_correlation.py
+++ b/emukit/quadrature/acquisitions/squared_correlation.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/uncertainty_sampling.py
+++ b/emukit/quadrature/acquisitions/uncertainty_sampling.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/acquisitions/uncertainty_sampling.py
+++ b/emukit/quadrature/acquisitions/uncertainty_sampling.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/emukit/quadrature/interfaces/__init__.py
+++ b/emukit/quadrature/interfaces/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/interfaces/__init__.py
+++ b/emukit/quadrature/interfaces/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Interfaces for the quadrature package."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/interfaces/base_gp.py
+++ b/emukit/quadrature/interfaces/base_gp.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/interfaces/base_gp.py
+++ b/emukit/quadrature/interfaces/base_gp.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/interfaces/standard_kernels.py
+++ b/emukit/quadrature/interfaces/standard_kernels.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/interfaces/standard_kernels.py
+++ b/emukit/quadrature/interfaces/standard_kernels.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Kernel embeddings for Bayesian quadrature."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/kernels/__init__.py
+++ b/emukit/quadrature/kernels/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/quadrature_brownian.py
+++ b/emukit/quadrature/kernels/quadrature_brownian.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The Brownian motion kernel embeddings."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Base class for kernel embeddings."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/kernels/quadrature_kernels.py
+++ b/emukit/quadrature/kernels/quadrature_kernels.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/quadrature_matern12.py
+++ b/emukit/quadrature/kernels/quadrature_matern12.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/quadrature_matern12.py
+++ b/emukit/quadrature/kernels/quadrature_matern12.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The product Matern12 kernel embeddings."""
 
 from typing import Union

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The product Matern32 kernel embeddings."""
 
 from typing import Union

--- a/emukit/quadrature/kernels/quadrature_matern32.py
+++ b/emukit/quadrature/kernels/quadrature_matern32.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/quadrature_matern52.py
+++ b/emukit/quadrature/kernels/quadrature_matern52.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/kernels/quadrature_matern52.py
+++ b/emukit/quadrature/kernels/quadrature_matern52.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The product Matern52 kernel embeddings."""
 
 from typing import Union

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The RBF kernel embeddings."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/kernels/quadrature_rbf.py
+++ b/emukit/quadrature/kernels/quadrature_rbf.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/loop/__init__.py
+++ b/emukit/quadrature/loop/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/loop/__init__.py
+++ b/emukit/quadrature/loop/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Loops for Bayesian quadrature."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/loop/bayesian_monte_carlo_loop.py
+++ b/emukit/quadrature/loop/bayesian_monte_carlo_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/loop/bayesian_monte_carlo_loop.py
+++ b/emukit/quadrature/loop/bayesian_monte_carlo_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/emukit/quadrature/loop/point_calculators/__init__.py
+++ b/emukit/quadrature/loop/point_calculators/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/loop/point_calculators/__init__.py
+++ b/emukit/quadrature/loop/point_calculators/__init__.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Point calculators for Bayesian quadrature."""
 
 from .quadrature_point_calculators import BayesianMonteCarloPointCalculator

--- a/emukit/quadrature/loop/point_calculators/quadrature_point_calculators.py
+++ b/emukit/quadrature/loop/point_calculators/quadrature_point_calculators.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/loop/point_calculators/quadrature_point_calculators.py
+++ b/emukit/quadrature/loop/point_calculators/quadrature_point_calculators.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/emukit/quadrature/loop/vanilla_bq_loop.py
+++ b/emukit/quadrature/loop/vanilla_bq_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/loop/vanilla_bq_loop.py
+++ b/emukit/quadrature/loop/vanilla_bq_loop.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from ...core.acquisition import Acquisition
 from ...core.loop import FixedIntervalUpdater, ModelUpdater, OuterLoop, SequentialPointCalculator

--- a/emukit/quadrature/loop/wsabil_loop.py
+++ b/emukit/quadrature/loop/wsabil_loop.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The WSABI-L loop"""
 
 

--- a/emukit/quadrature/loop/wsabil_loop.py
+++ b/emukit/quadrature/loop/wsabil_loop.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/__init__.py
+++ b/emukit/quadrature/measures/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/__init__.py
+++ b/emukit/quadrature/measures/__init__.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Integration measures."""
 
 from .domain import BoxDomain

--- a/emukit/quadrature/measures/domain.py
+++ b/emukit/quadrature/measures/domain.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/domain.py
+++ b/emukit/quadrature/measures/domain.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/gaussian_measure.py
+++ b/emukit/quadrature/measures/gaussian_measure.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/gaussian_measure.py
+++ b/emukit/quadrature/measures/gaussian_measure.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The Gaussian measure."""
 
 from typing import Union

--- a/emukit/quadrature/measures/integration_measure.py
+++ b/emukit/quadrature/measures/integration_measure.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/integration_measure.py
+++ b/emukit/quadrature/measures/integration_measure.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/lebesgue_measure.py
+++ b/emukit/quadrature/measures/lebesgue_measure.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/measures/lebesgue_measure.py
+++ b/emukit/quadrature/measures/lebesgue_measure.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The Lebesgue measure."""
 
 import numpy as np

--- a/emukit/quadrature/methods/__init__.py
+++ b/emukit/quadrature/methods/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/__init__.py
+++ b/emukit/quadrature/methods/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Bayesian quadrature models."""
 
 # Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/emukit/quadrature/methods/bounded_bq_model.py
+++ b/emukit/quadrature/methods/bounded_bq_model.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/bounded_bq_model.py
+++ b/emukit/quadrature/methods/bounded_bq_model.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """The bounded Bayesian quadrature model is with square-root warping."""
 
 from typing import Optional, Tuple

--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/vanilla_bq.py
+++ b/emukit/quadrature/methods/vanilla_bq.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/warped_bq_model.py
+++ b/emukit/quadrature/methods/warped_bq_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/warpings.py
+++ b/emukit/quadrature/methods/warpings.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Warpings as used by warped Bayesian quadrature models."""
 
 import abc

--- a/emukit/quadrature/methods/wsabi.py
+++ b/emukit/quadrature/methods/wsabi.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/quadrature/methods/wsabi.py
+++ b/emukit/quadrature/methods/wsabi.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """WSABI model as in Gunter et al. 2014"""
 
 

--- a/emukit/quadrature/typing.py
+++ b/emukit/quadrature/typing.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Types for the quadrature package."""
 
 from typing import List, Tuple

--- a/emukit/quadrature/typing.py
+++ b/emukit/quadrature/typing.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/samplers/__init__.py
+++ b/emukit/samplers/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/samplers/__init__.py
+++ b/emukit/samplers/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/samplers/mcmc_sampler.py
+++ b/emukit/samplers/mcmc_sampler.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/samplers/mcmc_sampler.py
+++ b/emukit/samplers/mcmc_sampler.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/sensitivity/__init__.py
+++ b/emukit/sensitivity/__init__.py
@@ -1,2 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/emukit/sensitivity/__init__.py
+++ b/emukit/sensitivity/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/emukit/sensitivity/__init__.py
+++ b/emukit/sensitivity/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/emukit/sensitivity/monte_carlo/__init__.py
+++ b/emukit/sensitivity/monte_carlo/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/sensitivity/monte_carlo/__init__.py
+++ b/emukit/sensitivity/monte_carlo/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/sensitivity/monte_carlo/monte_carlo_sensitivity.py
+++ b/emukit/sensitivity/monte_carlo/monte_carlo_sensitivity.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/sensitivity/monte_carlo/monte_carlo_sensitivity.py
+++ b/emukit/sensitivity/monte_carlo/monte_carlo_sensitivity.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/__init__.py
+++ b/emukit/test_functions/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/__init__.py
+++ b/emukit/test_functions/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/branin.py
+++ b/emukit/test_functions/branin.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/branin.py
+++ b/emukit/test_functions/branin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/forrester.py
+++ b/emukit/test_functions/forrester.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/forrester.py
+++ b/emukit/test_functions/forrester.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/__init__.py
+++ b/emukit/test_functions/multi_fidelity/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/__init__.py
+++ b/emukit/test_functions/multi_fidelity/__init__.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from .borehole import multi_fidelity_borehole_function  # noqa: F401
 from .branin import multi_fidelity_branin_function  # noqa: F401
 from .currin import multi_fidelity_currin_function  # noqa: F401

--- a/emukit/test_functions/multi_fidelity/borehole.py
+++ b/emukit/test_functions/multi_fidelity/borehole.py
@@ -1,5 +1,10 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/test_functions/multi_fidelity/borehole.py
+++ b/emukit/test_functions/multi_fidelity/borehole.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/branin.py
+++ b/emukit/test_functions/multi_fidelity/branin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/branin.py
+++ b/emukit/test_functions/multi_fidelity/branin.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/test_functions/multi_fidelity/currin.py
+++ b/emukit/test_functions/multi_fidelity/currin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/currin.py
+++ b/emukit/test_functions/multi_fidelity/currin.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/test_functions/multi_fidelity/hartmann.py
+++ b/emukit/test_functions/multi_fidelity/hartmann.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/hartmann.py
+++ b/emukit/test_functions/multi_fidelity/hartmann.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/test_functions/multi_fidelity/park.py
+++ b/emukit/test_functions/multi_fidelity/park.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/multi_fidelity/park.py
+++ b/emukit/test_functions/multi_fidelity/park.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from typing import Tuple
 
 import numpy as np

--- a/emukit/test_functions/non_linear_sin.py
+++ b/emukit/test_functions/non_linear_sin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/non_linear_sin.py
+++ b/emukit/test_functions/non_linear_sin.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.core import ContinuousParameter, InformationSourceParameter, ParameterSpace

--- a/emukit/test_functions/quadrature/__init__.py
+++ b/emukit/test_functions/quadrature/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/__init__.py
+++ b/emukit/test_functions/quadrature/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/baselines.py
+++ b/emukit/test_functions/quadrature/baselines.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/baselines.py
+++ b/emukit/test_functions/quadrature/baselines.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/circular_gaussian.py
+++ b/emukit/test_functions/quadrature/circular_gaussian.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/circular_gaussian.py
+++ b/emukit/test_functions/quadrature/circular_gaussian.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/hennig1D.py
+++ b/emukit/test_functions/quadrature/hennig1D.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/hennig1D.py
+++ b/emukit/test_functions/quadrature/hennig1D.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/hennig2D.py
+++ b/emukit/test_functions/quadrature/hennig2D.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/emukit/test_functions/quadrature/hennig2D.py
+++ b/emukit/test_functions/quadrature/hennig2D.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/sombrero2D.py
+++ b/emukit/test_functions/quadrature/sombrero2D.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/quadrature/sombrero2D.py
+++ b/emukit/test_functions/quadrature/sombrero2D.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/sensitivity/__init__.py
+++ b/emukit/test_functions/sensitivity/__init__.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/sensitivity/__init__.py
+++ b/emukit/test_functions/sensitivity/__init__.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/sensitivity/ishigami.py
+++ b/emukit/test_functions/sensitivity/ishigami.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/sensitivity/ishigami.py
+++ b/emukit/test_functions/sensitivity/ishigami.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/sixhumpcamel.py
+++ b/emukit/test_functions/sixhumpcamel.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/emukit/test_functions/sixhumpcamel.py
+++ b/emukit/test_functions/sixhumpcamel.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_constrained_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/integration_tests/emukit/bayesian_optimization/test_create_bayesian_optimization_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_create_bayesian_optimization_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.examples.gp_bayesian_optimization.enums import AcquisitionType, ModelType

--- a/integration_tests/emukit/bayesian_optimization/test_create_bayesian_optimization_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_create_bayesian_optimization_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_local_penalization_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_local_penalization_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_local_penalization_loop.py
+++ b/integration_tests/emukit/bayesian_optimization/test_local_penalization_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/integration_tests/emukit/bayesian_optimization/test_optimization_with_categorical_variables.py
+++ b/integration_tests/emukit/bayesian_optimization/test_optimization_with_categorical_variables.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_optimization_with_categorical_variables.py
+++ b/integration_tests/emukit/bayesian_optimization/test_optimization_with_categorical_variables.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/integration_tests/emukit/bayesian_optimization/test_single_objective_bayesian_optimization.py
+++ b/integration_tests/emukit/bayesian_optimization/test_single_objective_bayesian_optimization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_single_objective_bayesian_optimization.py
+++ b/integration_tests/emukit/bayesian_optimization/test_single_objective_bayesian_optimization.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.core.continuous_parameter import ContinuousParameter

--- a/integration_tests/emukit/bayesian_optimization/test_unknown_constraints_bayesian_optimization.py
+++ b/integration_tests/emukit/bayesian_optimization/test_unknown_constraints_bayesian_optimization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/bayesian_optimization/test_unknown_constraints_bayesian_optimization.py
+++ b/integration_tests/emukit/bayesian_optimization/test_unknown_constraints_bayesian_optimization.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.core.continuous_parameter import ContinuousParameter

--- a/integration_tests/emukit/benchmarking/test_benchmarker.py
+++ b/integration_tests/emukit/benchmarking/test_benchmarker.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/benchmarking/test_benchmarker.py
+++ b/integration_tests/emukit/benchmarking/test_benchmarker.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 import pytest

--- a/integration_tests/emukit/experimental_design/test_experimental_design_with_categorical.py
+++ b/integration_tests/emukit/experimental_design/test_experimental_design_with_categorical.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/experimental_design/test_experimental_design_with_categorical.py
+++ b/integration_tests/emukit/experimental_design/test_experimental_design_with_categorical.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/integration_tests/emukit/experimental_design/test_multi_source_experimental_design.py
+++ b/integration_tests/emukit/experimental_design/test_multi_source_experimental_design.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/experimental_design/test_multi_source_experimental_design.py
+++ b/integration_tests/emukit/experimental_design/test_multi_source_experimental_design.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/integration_tests/emukit/fabolas/__init__.py
+++ b/integration_tests/emukit/fabolas/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/integration_tests/emukit/fabolas/__init__.py
+++ b/integration_tests/emukit/fabolas/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/integration_tests/emukit/fabolas/__init__.py
+++ b/integration_tests/emukit/fabolas/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/integration_tests/emukit/fabolas/test_continuous_entropy_search.py
+++ b/integration_tests/emukit/fabolas/test_continuous_entropy_search.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.core import ContinuousParameter, ParameterSpace

--- a/integration_tests/emukit/fabolas/test_continuous_entropy_search.py
+++ b/integration_tests/emukit/fabolas/test_continuous_entropy_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/fabolas/test_fabolas_model.py
+++ b/integration_tests/emukit/fabolas/test_fabolas_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/fabolas/test_fabolas_model.py
+++ b/integration_tests/emukit/fabolas/test_fabolas_model.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/integration_tests/emukit/models/test_bohamiann.py
+++ b/integration_tests/emukit/models/test_bohamiann.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/models/test_bohamiann.py
+++ b/integration_tests/emukit/models/test_bohamiann.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/integration_tests/emukit/models/test_random_forest.py
+++ b/integration_tests/emukit/models/test_random_forest.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/models/test_random_forest.py
+++ b/integration_tests/emukit/models/test_random_forest.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/integration_tests/emukit/models/test_sklearn_model_wrapper.py
+++ b/integration_tests/emukit/models/test_sklearn_model_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/models/test_sklearn_model_wrapper.py
+++ b/integration_tests/emukit/models/test_sklearn_model_wrapper.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from sklearn.gaussian_process import GaussianProcessRegressor

--- a/integration_tests/emukit/notebooks/test_notebooks.py
+++ b/integration_tests/emukit/notebooks/test_notebooks.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # These are notebooks that take too long to run so are not tested here
 # The parallel evel notebook is too flaky and often fails the builds for no reason
 excluded_notebooks = ['Emukit-tutorial-multi-fidelity-bayesian-optimization.ipynb',

--- a/integration_tests/emukit/notebooks/test_notebooks.py
+++ b/integration_tests/emukit/notebooks/test_notebooks.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/profet/__init__.py
+++ b/integration_tests/emukit/profet/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/integration_tests/emukit/profet/__init__.py
+++ b/integration_tests/emukit/profet/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/integration_tests/emukit/profet/__init__.py
+++ b/integration_tests/emukit/profet/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/integration_tests/emukit/profet/test_performance_assessment.py
+++ b/integration_tests/emukit/profet/test_performance_assessment.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.examples.profet.performance_assessment import compute_ecdf, compute_ranks, compute_runtime_feval

--- a/integration_tests/emukit/profet/test_performance_assessment.py
+++ b/integration_tests/emukit/profet/test_performance_assessment.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/quadrature/test_bayesian_monte_carlo_loop.py
+++ b/integration_tests/emukit/quadrature/test_bayesian_monte_carlo_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/quadrature/test_bayesian_monte_carlo_loop.py
+++ b/integration_tests/emukit/quadrature/test_bayesian_monte_carlo_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/integration_tests/emukit/quadrature/test_vanilla_bq_loop.py
+++ b/integration_tests/emukit/quadrature/test_vanilla_bq_loop.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/quadrature/test_vanilla_bq_loop.py
+++ b/integration_tests/emukit/quadrature/test_vanilla_bq_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/quadrature/test_wsabil_loop.py
+++ b/integration_tests/emukit/quadrature/test_wsabil_loop.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/integration_tests/emukit/quadrature/test_wsabil_loop.py
+++ b/integration_tests/emukit/quadrature/test_wsabil_loop.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 import pytest

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+#
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License").
 #   You may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,9 @@
 # Copyright 2024 The Emukit Authors. All Rights Reserved.
-#
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-#
-#   Licensed under the Apache License, Version 2.0 (the "License").
-#   You may not use this file except in compliance with the License.
-#   A copy of the License is located at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-#   or in the "license" file accompanying this file. This file is distributed
-#   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-#   express or implied. See the License for the specific language governing
-#   permissions and limitations under the License.
-# ==============================================================================
+# SPDX-License-Identifier: Apache-2.0
+
 
 import sys
 

--- a/tests/emukit/bayesian_optimization/__init__.py
+++ b/tests/emukit/bayesian_optimization/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/tests/emukit/bayesian_optimization/__init__.py
+++ b/tests/emukit/bayesian_optimization/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/tests/emukit/bayesian_optimization/__init__.py
+++ b/tests/emukit/bayesian_optimization/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/emukit/bayesian_optimization/test_bayesian_optimization_loop.py
+++ b/tests/emukit/bayesian_optimization/test_bayesian_optimization_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import mock
 import numpy as np

--- a/tests/emukit/bayesian_optimization/test_bayesian_optimization_loop.py
+++ b/tests/emukit/bayesian_optimization/test_bayesian_optimization_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_constrained_loop.py
+++ b/tests/emukit/bayesian_optimization/test_constrained_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_constrained_loop.py
+++ b/tests/emukit/bayesian_optimization/test_constrained_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/tests/emukit/bayesian_optimization/test_cost_sensitive_bayesian_optimization.py
+++ b/tests/emukit/bayesian_optimization/test_cost_sensitive_bayesian_optimization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_cost_sensitive_bayesian_optimization.py
+++ b/tests/emukit/bayesian_optimization/test_cost_sensitive_bayesian_optimization.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 

--- a/tests/emukit/bayesian_optimization/test_entropy_search.py
+++ b/tests/emukit/bayesian_optimization/test_entropy_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_entropy_search.py
+++ b/tests/emukit/bayesian_optimization/test_entropy_search.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/bayesian_optimization/test_epmgp.py
+++ b/tests/emukit/bayesian_optimization/test_epmgp.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_epmgp.py
+++ b/tests/emukit/bayesian_optimization/test_epmgp.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.bayesian_optimization import epmgp

--- a/tests/emukit/bayesian_optimization/test_local_penalization.py
+++ b/tests/emukit/bayesian_optimization/test_local_penalization.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_local_penalization.py
+++ b/tests/emukit/bayesian_optimization/test_local_penalization.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 from scipy.optimize import check_grad
 

--- a/tests/emukit/bayesian_optimization/test_local_penalization_calculator.py
+++ b/tests/emukit/bayesian_optimization/test_local_penalization_calculator.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import mock
 import numpy as np

--- a/tests/emukit/bayesian_optimization/test_local_penalization_calculator.py
+++ b/tests/emukit/bayesian_optimization/test_local_penalization_calculator.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_max_value_entropy_search.py
+++ b/tests/emukit/bayesian_optimization/test_max_value_entropy_search.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_max_value_entropy_search.py
+++ b/tests/emukit/bayesian_optimization/test_max_value_entropy_search.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/bayesian_optimization/test_mean_plugin_expected_improvement.py
+++ b/tests/emukit/bayesian_optimization/test_mean_plugin_expected_improvement.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_mean_plugin_expected_improvement.py
+++ b/tests/emukit/bayesian_optimization/test_mean_plugin_expected_improvement.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from unittest.mock import MagicMock
 
 import numpy as np

--- a/tests/emukit/bayesian_optimization/test_multipoint_expected_improvement.py
+++ b/tests/emukit/bayesian_optimization/test_multipoint_expected_improvement.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/bayesian_optimization/test_multipoint_expected_improvement.py
+++ b/tests/emukit/bayesian_optimization/test_multipoint_expected_improvement.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 from scipy.optimize import check_grad

--- a/tests/emukit/benchmarking/test_benchmark_plot.py
+++ b/tests/emukit/benchmarking/test_benchmark_plot.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/benchmarking/test_benchmark_plot.py
+++ b/tests/emukit/benchmarking/test_benchmark_plot.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/benchmarking/test_benchmark_result.py
+++ b/tests/emukit/benchmarking/test_benchmark_result.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/tests/emukit/benchmarking/test_benchmark_result.py
+++ b/tests/emukit/benchmarking/test_benchmark_result.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/benchmarking/test_metrics.py
+++ b/tests/emukit/benchmarking/test_metrics.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/benchmarking/test_metrics.py
+++ b/tests/emukit/benchmarking/test_metrics.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 

--- a/tests/emukit/benchmarking/test_random_search.py
+++ b/tests/emukit/benchmarking/test_random_search.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/benchmarking/test_random_search.py
+++ b/tests/emukit/benchmarking/test_random_search.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.benchmarking.loop_benchmarking.random_search import RandomSearch

--- a/tests/emukit/conftest.py
+++ b/tests/emukit/conftest.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/conftest.py
+++ b/tests/emukit/conftest.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """
 This file is where to put fixtures that are to be shared across different test files
 """

--- a/tests/emukit/core/optimization/conftest.py
+++ b/tests/emukit/core/optimization/conftest.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/conftest.py
+++ b/tests/emukit/core/optimization/conftest.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/core/optimization/test_anchor_points_generator.py
+++ b/tests/emukit/core/optimization/test_anchor_points_generator.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_anchor_points_generator.py
+++ b/tests/emukit/core/optimization/test_anchor_points_generator.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 import pytest

--- a/tests/emukit/core/optimization/test_context_manager.py
+++ b/tests/emukit/core/optimization/test_context_manager.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_context_manager.py
+++ b/tests/emukit/core/optimization/test_context_manager.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/core/optimization/test_gradient_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_gradient_acquisition_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/tests/emukit/core/optimization/test_gradient_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_gradient_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_local_search_acquisition_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from numpy.testing import assert_almost_equal, assert_equal

--- a/tests/emukit/core/optimization/test_multi_source_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_multi_source_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_multi_source_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_multi_source_acquisition_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 from numpy.testing import assert_array_equal
 

--- a/tests/emukit/core/optimization/test_optimizer.py
+++ b/tests/emukit/core/optimization/test_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_optimizer.py
+++ b/tests/emukit/core/optimization/test_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/core/optimization/test_random_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_random_search_acquisition_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_random_search_acquisition_optimizer.py
+++ b/tests/emukit/core/optimization/test_random_search_acquisition_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 from numpy.testing import assert_array_equal
 

--- a/tests/emukit/core/optimization/test_trust_region_constrained_optimizer.py
+++ b/tests/emukit/core/optimization/test_trust_region_constrained_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/optimization/test_trust_region_constrained_optimizer.py
+++ b/tests/emukit/core/optimization/test_trust_region_constrained_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/core/test_acquisition.py
+++ b/tests/emukit/core/test_acquisition.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_acquisition.py
+++ b/tests/emukit/core/test_acquisition.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 import pytest

--- a/tests/emukit/core/test_categorical_parameter.py
+++ b/tests/emukit/core/test_categorical_parameter.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_categorical_parameter.py
+++ b/tests/emukit/core/test_categorical_parameter.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 import pytest

--- a/tests/emukit/core/test_constraints.py
+++ b/tests/emukit/core/test_constraints.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_constraints.py
+++ b/tests/emukit/core/test_constraints.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/core/test_encodings.py
+++ b/tests/emukit/core/test_encodings.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/tests/emukit/core/test_encodings.py
+++ b/tests/emukit/core/test_encodings.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_loop_state.py
+++ b/tests/emukit/core/test_loop_state.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/tests/emukit/core/test_loop_state.py
+++ b/tests/emukit/core/test_loop_state.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_loop_steps.py
+++ b/tests/emukit/core/test_loop_steps.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_loop_steps.py
+++ b/tests/emukit/core/test_loop_steps.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 

--- a/tests/emukit/core/test_model_free_designs.py
+++ b/tests/emukit/core/test_model_free_designs.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_model_free_designs.py
+++ b/tests/emukit/core/test_model_free_designs.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from emukit.core import CategoricalParameter, ContinuousParameter, DiscreteParameter, ParameterSpace
 from emukit.core.initial_designs import RandomDesign
 from emukit.core.initial_designs.latin_design import LatinDesign

--- a/tests/emukit/core/test_multi_source_optimizer.py
+++ b/tests/emukit/core/test_multi_source_optimizer.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_multi_source_optimizer.py
+++ b/tests/emukit/core/test_multi_source_optimizer.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 import pytest

--- a/tests/emukit/core/test_outer_loop.py
+++ b/tests/emukit/core/test_outer_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import mock
 import numpy as np

--- a/tests/emukit/core/test_outer_loop.py
+++ b/tests/emukit/core/test_outer_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_parameter_space.py
+++ b/tests/emukit/core/test_parameter_space.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_parameter_space.py
+++ b/tests/emukit/core/test_parameter_space.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from unittest import mock
 
 import numpy as np

--- a/tests/emukit/core/test_parameters.py
+++ b/tests/emukit/core/test_parameters.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_parameters.py
+++ b/tests/emukit/core/test_parameters.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/core/test_stopping_conditions.py
+++ b/tests/emukit/core/test_stopping_conditions.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/core/test_stopping_conditions.py
+++ b/tests/emukit/core/test_stopping_conditions.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 

--- a/tests/emukit/core/test_user_function.py
+++ b/tests/emukit/core/test_user_function.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 from numpy.testing import assert_array_equal

--- a/tests/emukit/core/test_user_function.py
+++ b/tests/emukit/core/test_user_function.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/examples/test_simple_gp_model.py
+++ b/tests/emukit/examples/test_simple_gp_model.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/examples/test_simple_gp_model.py
+++ b/tests/emukit/examples/test_simple_gp_model.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/experimental_design/__init__.py
+++ b/tests/emukit/experimental_design/__init__.py
@@ -1,0 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/tests/emukit/experimental_design/__init__.py
+++ b/tests/emukit/experimental_design/__init__.py
@@ -3,5 +3,3 @@
 
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/tests/emukit/experimental_design/__init__.py
+++ b/tests/emukit/experimental_design/__init__.py
@@ -1,5 +1,5 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/emukit/experimental_design/test_batch_experimental_design.py
+++ b/tests/emukit/experimental_design/test_batch_experimental_design.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import mock
 import numpy as np

--- a/tests/emukit/experimental_design/test_batch_experimental_design.py
+++ b/tests/emukit/experimental_design/test_batch_experimental_design.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/experimental_design/test_experimental_design_loop.py
+++ b/tests/emukit/experimental_design/test_experimental_design_loop.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/experimental_design/test_experimental_design_loop.py
+++ b/tests/emukit/experimental_design/test_experimental_design_loop.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 from numpy.testing import assert_array_equal

--- a/tests/emukit/experimental_design/test_integrated_variance.py
+++ b/tests/emukit/experimental_design/test_integrated_variance.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/experimental_design/test_integrated_variance.py
+++ b/tests/emukit/experimental_design/test_integrated_variance.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/model_wrappers/__init__.py
+++ b/tests/emukit/model_wrappers/__init__.py
@@ -1,4 +1,2 @@
 # Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-

--- a/tests/emukit/model_wrappers/__init__.py
+++ b/tests/emukit/model_wrappers/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+

--- a/tests/emukit/model_wrappers/__init__.py
+++ b/tests/emukit/model_wrappers/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
+++ b/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
+++ b/tests/emukit/model_wrappers/test_gpy_wrappers_quadrature.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Basic tests for quadrature GPy wrappers."""
 
 import GPy

--- a/tests/emukit/multi_fidelity/test_convert_list_to_array.py
+++ b/tests/emukit/multi_fidelity/test_convert_list_to_array.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/multi_fidelity/test_convert_list_to_array.py
+++ b/tests/emukit/multi_fidelity/test_convert_list_to_array.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 import pytest
 

--- a/tests/emukit/multi_fidelity/test_kernels.py
+++ b/tests/emukit/multi_fidelity/test_kernels.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """
 Tests for multi-fidelity kernels
 """

--- a/tests/emukit/multi_fidelity/test_kernels.py
+++ b/tests/emukit/multi_fidelity/test_kernels.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/multi_fidelity/test_models.py
+++ b/tests/emukit/multi_fidelity/test_models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/multi_fidelity/test_models.py
+++ b/tests/emukit/multi_fidelity/test_models.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 import pytest

--- a/tests/emukit/multi_fidelity/test_non_linear_models.py
+++ b/tests/emukit/multi_fidelity/test_non_linear_models.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/multi_fidelity/test_non_linear_models.py
+++ b/tests/emukit/multi_fidelity/test_non_linear_models.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import GPy
 import numpy as np
 import pytest

--- a/tests/emukit/quadrature/ground_truth_integrals_methods.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_methods.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/ground_truth_integrals_methods.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_methods.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
+++ b/tests/emukit/quadrature/ground_truth_integrals_qkernel.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/emukit/quadrature/test_domain.py
+++ b/tests/emukit/quadrature/test_domain.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_domain.py
+++ b/tests/emukit/quadrature/test_domain.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_measures.py
+++ b/tests/emukit/quadrature/test_measures.py
@@ -1,5 +1,9 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from dataclasses import dataclass
 

--- a/tests/emukit/quadrature/test_measures.py
+++ b/tests/emukit/quadrature/test_measures.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_quadrature_acquisitions.py
+++ b/tests/emukit/quadrature/test_quadrature_acquisitions.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_quadrature_acquisitions.py
+++ b/tests/emukit/quadrature/test_quadrature_acquisitions.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_quadrature_kernels.py
+++ b/tests/emukit/quadrature/test_quadrature_kernels.py
@@ -1,5 +1,6 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+
 
 from dataclasses import dataclass
 

--- a/tests/emukit/quadrature/test_quadrature_models.py
+++ b/tests/emukit/quadrature/test_quadrature_models.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_quadrature_models.py
+++ b/tests/emukit/quadrature/test_quadrature_models.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from dataclasses import dataclass
 from math import isclose
 

--- a/tests/emukit/quadrature/test_warpings.py
+++ b/tests/emukit/quadrature/test_warpings.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/test_warpings.py
+++ b/tests/emukit/quadrature/test_warpings.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from collections import namedtuple
 
 import numpy as np

--- a/tests/emukit/quadrature/utils.py
+++ b/tests/emukit/quadrature/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/quadrature/utils.py
+++ b/tests/emukit/quadrature/utils.py
@@ -1,3 +1,7 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 """Helper functions for quadrature tests"""
 
 from math import isclose

--- a/tests/emukit/sensitivity/test_emukit_sensitivity.py
+++ b/tests/emukit/sensitivity/test_emukit_sensitivity.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/sensitivity/test_emukit_sensitivity.py
+++ b/tests/emukit/sensitivity/test_emukit_sensitivity.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import mock
 import numpy as np
 import pytest

--- a/tests/emukit/test_acquisitions.py
+++ b/tests/emukit/test_acquisitions.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 from collections import namedtuple
 
 import numpy as np

--- a/tests/emukit/test_acquisitions.py
+++ b/tests/emukit/test_acquisitions.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_baselines.py
+++ b/tests/emukit/test_functions/test_baselines.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_baselines.py
+++ b/tests/emukit/test_functions/test_baselines.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_branin.py
+++ b/tests/emukit/test_functions/test_branin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_branin.py
+++ b/tests/emukit/test_functions/test_branin.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.test_functions import branin_function

--- a/tests/emukit/test_functions/test_circular_gaussian.py
+++ b/tests/emukit/test_functions/test_circular_gaussian.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_circular_gaussian.py
+++ b/tests/emukit/test_functions/test_circular_gaussian.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_forrester.py
+++ b/tests/emukit/test_functions/test_forrester.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_forrester.py
+++ b/tests/emukit/test_functions/test_forrester.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.test_functions import forrester_function

--- a/tests/emukit/test_functions/test_hennig1d.py
+++ b/tests/emukit/test_functions/test_hennig1d.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_hennig1d.py
+++ b/tests/emukit/test_functions/test_hennig1d.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_hennig2d.py
+++ b/tests/emukit/test_functions/test_hennig2d.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/emukit/test_functions/test_hennig2d.py
+++ b/tests/emukit/test_functions/test_hennig2d.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_ishigami_function.py
+++ b/tests/emukit/test_functions/test_ishigami_function.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.test_functions.sensitivity import Ishigami

--- a/tests/emukit/test_functions/test_ishigami_function.py
+++ b/tests/emukit/test_functions/test_ishigami_function.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_multi_fidelity_functions.py
+++ b/tests/emukit/test_functions/test_multi_fidelity_functions.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_multi_fidelity_functions.py
+++ b/tests/emukit/test_functions/test_multi_fidelity_functions.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import pytest
 
 from emukit.core.initial_designs import RandomDesign

--- a/tests/emukit/test_functions/test_nonlinear_sin.py
+++ b/tests/emukit/test_functions/test_nonlinear_sin.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_nonlinear_sin.py
+++ b/tests/emukit/test_functions/test_nonlinear_sin.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.test_functions.non_linear_sin import nonlinear_sin_high, nonlinear_sin_low

--- a/tests/emukit/test_functions/test_sixhumpcamel.py
+++ b/tests/emukit/test_functions/test_sixhumpcamel.py
@@ -1,3 +1,10 @@
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
 import numpy as np
 
 from emukit.test_functions import sixhumpcamel_function

--- a/tests/emukit/test_functions/test_sixhumpcamel.py
+++ b/tests/emukit/test_functions/test_sixhumpcamel.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_sombrero2d.py
+++ b/tests/emukit/test_functions/test_sombrero2d.py
@@ -1,4 +1,7 @@
-# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 

--- a/tests/emukit/test_functions/test_sombrero2d.py
+++ b/tests/emukit/test_functions/test_sombrero2d.py
@@ -1,7 +1,7 @@
-# Copyright 2024 The Emukit Authors. All Rights Reserved.
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Test PR to see how headers are looking like.

@apaleyes I can change the text as needed. This is just to see if things work. All files before "2020-10-26" should have two copyright notices in the header and the ones created after only one. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
