### PR TITLE
BQ stopping criteria that depend on model statistics

### DIFF
--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -101,6 +101,7 @@ class OuterLoop(object):
             _log.info("Iteration {}".format(self.loop_state.iteration))
 
             self._update_models()
+            self._update_loop_state_custom()
             new_x = self.candidate_point_calculator.compute_next_points(self.loop_state, context)
             _log.debug("Next suggested point(s): {}".format(new_x))
             results = user_function.evaluate(new_x)
@@ -109,7 +110,13 @@ class OuterLoop(object):
             self.iteration_end_event(self, self.loop_state)
 
         self._update_models()
+        self._update_loop_state_custom()
         _log.info("Finished outer loop")
+
+    def _update_loop_state_custom(self) -> None:
+        """This method is called after the models are updated. Override this function to store model quantities
+        in the loop state."""
+        pass
 
     def _update_models(self):
         for model_updater in self.model_updaters:

--- a/emukit/core/loop/outer_loop.py
+++ b/emukit/core/loop/outer_loop.py
@@ -101,7 +101,7 @@ class OuterLoop(object):
             _log.info("Iteration {}".format(self.loop_state.iteration))
 
             self._update_models()
-            self._update_loop_state_custom()
+            self._update_loop_state()
             new_x = self.candidate_point_calculator.compute_next_points(self.loop_state, context)
             _log.debug("Next suggested point(s): {}".format(new_x))
             results = user_function.evaluate(new_x)
@@ -110,12 +110,12 @@ class OuterLoop(object):
             self.iteration_end_event(self, self.loop_state)
 
         self._update_models()
-        self._update_loop_state_custom()
+        self._update_loop_state()
         _log.info("Finished outer loop")
 
-    def _update_loop_state_custom(self) -> None:
-        """This method is called after the models are updated. Override this function to store model quantities
-        in the loop state."""
+    def _update_loop_state(self) -> None:
+        """This method is called after the models are updated. Override this function to store additional statistics
+        other than the collected points and function values in the loop state."""
         pass
 
     def _update_models(self):

--- a/emukit/quadrature/loop/__init__.py
+++ b/emukit/quadrature/loop/__init__.py
@@ -12,12 +12,18 @@
 
 
 from .bayesian_monte_carlo_loop import BayesianMonteCarlo  # noqa: F401
+from .bq_loop_state import QuadratureLoopState
+from .bq_outer_loop import QuadratureOuterLoop
+from .bq_stopping_conditions import CoefficientOfVariationStoppingCondition
 from .vanilla_bq_loop import VanillaBayesianQuadratureLoop  # noqa: F401
 from .wsabil_loop import WSABILLoop  # noqa: F401
 
 __all__ = [
+    "QuadratureOuterLoop",
     "BayesianMonteCarlo",
     "VanillaBayesianQuadratureLoop",
     "WSABILLoop",
+    "QuadratureLoopState",
     "point_calculators",
+    "CoefficientOfVariationStoppingCondition",
 ]

--- a/emukit/quadrature/loop/bayesian_monte_carlo_loop.py
+++ b/emukit/quadrature/loop/bayesian_monte_carlo_loop.py
@@ -8,14 +8,15 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from ...core.loop import FixedIntervalUpdater, ModelUpdater, OuterLoop
-from ...core.loop.loop_state import create_loop_state
+from ...core.loop import FixedIntervalUpdater, ModelUpdater
 from ...core.parameter_space import ParameterSpace
 from ..loop.point_calculators import BayesianMonteCarloPointCalculator
 from ..methods import WarpedBayesianQuadratureModel
+from .bq_loop_state import create_bq_loop_state
+from .bq_outer_loop import QuadratureOuterLoop
 
 
-class BayesianMonteCarlo(OuterLoop):
+class BayesianMonteCarlo(QuadratureOuterLoop):
     """The loop for Bayesian Monte Carlo (BMC).
 
 
@@ -61,7 +62,7 @@ class BayesianMonteCarlo(OuterLoop):
 
         space = ParameterSpace(model.reasonable_box_bounds.convert_to_list_of_continuous_parameters())
         candidate_point_calculator = BayesianMonteCarloPointCalculator(model, space)
-        loop_state = create_loop_state(model.X, model.Y)
+        loop_state = create_bq_loop_state(model.X, model.Y)
 
         super().__init__(candidate_point_calculator, model_updater, loop_state)
 

--- a/emukit/quadrature/loop/bq_loop_state.py
+++ b/emukit/quadrature/loop/bq_loop_state.py
@@ -1,0 +1,74 @@
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import List, Optional
+
+import numpy as np
+
+from ...core.loop.loop_state import LoopState, create_loop_state
+from ...core.loop.user_function_result import UserFunctionResult
+
+
+class BQLoopState(LoopState):
+    """Contains the state of the BQ loop, which includes a history of all function evaluations and integral mean and
+    variance estimates.
+
+    :param initial_results:
+    :param initial_integral_means:
+    :param initial_integral_vars:
+
+    :raises ValueError: If ``initial_integral_means`` and ``initial_integral_vars`` have different length.
+
+    """
+    def __init__(
+        self,
+        initial_results: List[UserFunctionResult],
+        initial_integral_means: Optional[List[float]] = None,
+        initial_integral_vars: Optional[List[float]] = None,
+    ) -> None:
+        super().__init__(initial_results)
+
+        self.integral_means = initial_integral_means
+        if self.integral_means is None:
+            self.integral_means = []
+
+        self.integral_vars = initial_integral_vars
+        if self.integral_vars is None:
+            self.integral_vars = []
+
+        if len(self.integral_means) != len(self.integral_vars):
+            raise ValueError(
+                f"initial integral means list must have same length ({len(self.integral_means)}) "
+                f"as initial integral variances list ({len(self.integral_vars)})."
+            )
+
+    def update_integral_stats(self, integral_mean: float, integral_var: float) -> None:
+        """Adds the latest integral mean and variance to the loop state.
+
+        :param integral_mean: The latest integral mean estimate.
+        :param integral_var: The latest integral variance.
+        """
+        self.integral_means.append(integral_mean)
+        self.integral_vars.append(integral_var)
+
+
+def create_bq_loop_state(
+    x_init: np.ndarray,
+    y_init: np.ndarray,
+    initial_integral_means: Optional[List[float]] = None,
+    initial_integral_vars: Optional[List[float]] = None,
+    **kwargs,
+) -> BQLoopState:
+    """Creates a bq loop state object using the provided data.
+
+    :param x_init: x values for initial function evaluations. Shape: (n_initial_points x n_input_dims)
+    :param y_init: y values for initial function evaluations. Shape: (n_initial_points x n_output_dims)
+    :param initial_integral_means:
+    :param initial_integral_vars:
+    :param kwargs: extra outputs observed from a function evaluation. Shape: (n_initial_points x n_dims)
+    :return: The bq loop state.
+    """
+
+    loop_state = create_loop_state(x_init, y_init, **kwargs)
+    return BQLoopState(loop_state.results, initial_integral_means, initial_integral_vars)

--- a/emukit/quadrature/loop/bq_loop_state.py
+++ b/emukit/quadrature/loop/bq_loop_state.py
@@ -14,34 +14,16 @@ class BQLoopState(LoopState):
     """Contains the state of the BQ loop, which includes a history of all function evaluations and integral mean and
     variance estimates.
 
-    :param initial_results:
-    :param initial_integral_means:
-    :param initial_integral_vars:
-
-    :raises ValueError: If ``initial_integral_means`` and ``initial_integral_vars`` have different length.
+    :param initial_results: The results from previous integrand evaluations.
 
     """
-    def __init__(
-        self,
-        initial_results: List[UserFunctionResult],
-        initial_integral_means: Optional[List[float]] = None,
-        initial_integral_vars: Optional[List[float]] = None,
-    ) -> None:
+
+    def __init__(self, initial_results: List[UserFunctionResult]) -> None:
+
         super().__init__(initial_results)
 
-        self.integral_means = initial_integral_means
-        if self.integral_means is None:
-            self.integral_means = []
-
-        self.integral_vars = initial_integral_vars
-        if self.integral_vars is None:
-            self.integral_vars = []
-
-        if len(self.integral_means) != len(self.integral_vars):
-            raise ValueError(
-                f"initial integral means list must have same length ({len(self.integral_means)}) "
-                f"as initial integral variances list ({len(self.integral_vars)})."
-            )
+        self.integral_means = []
+        self.integral_vars = []
 
     def update_integral_stats(self, integral_mean: float, integral_var: float) -> None:
         """Adds the latest integral mean and variance to the loop state.
@@ -53,22 +35,14 @@ class BQLoopState(LoopState):
         self.integral_vars.append(integral_var)
 
 
-def create_bq_loop_state(
-    x_init: np.ndarray,
-    y_init: np.ndarray,
-    initial_integral_means: Optional[List[float]] = None,
-    initial_integral_vars: Optional[List[float]] = None,
-    **kwargs,
-) -> BQLoopState:
-    """Creates a bq loop state object using the provided data.
+def create_bq_loop_state(x_init: np.ndarray, y_init: np.ndarray, **kwargs) -> BQLoopState:
+    """Creates a BQ loop state object using the provided data.
 
     :param x_init: x values for initial function evaluations. Shape: (n_initial_points x n_input_dims)
     :param y_init: y values for initial function evaluations. Shape: (n_initial_points x n_output_dims)
-    :param initial_integral_means:
-    :param initial_integral_vars:
     :param kwargs: extra outputs observed from a function evaluation. Shape: (n_initial_points x n_dims)
-    :return: The bq loop state.
+    :return: The BQ loop state.
     """
 
     loop_state = create_loop_state(x_init, y_init, **kwargs)
-    return BQLoopState(loop_state.results, initial_integral_means, initial_integral_vars)
+    return BQLoopState(loop_state.results)

--- a/emukit/quadrature/loop/bq_loop_state.py
+++ b/emukit/quadrature/loop/bq_loop_state.py
@@ -10,8 +10,8 @@ from ...core.loop.loop_state import LoopState, create_loop_state
 from ...core.loop.user_function_result import UserFunctionResult
 
 
-class BQLoopState(LoopState):
-    """Contains the state of the BQ loop, which includes a history of all function evaluations and integral mean and
+class QuadratureLoopState(LoopState):
+    """Contains the state of the BQ loop, which includes a history of all integrand evaluations and integral mean and
     variance estimates.
 
     :param initial_results: The results from previous integrand evaluations.
@@ -35,7 +35,7 @@ class BQLoopState(LoopState):
         self.integral_vars.append(integral_var)
 
 
-def create_bq_loop_state(x_init: np.ndarray, y_init: np.ndarray, **kwargs) -> BQLoopState:
+def create_bq_loop_state(x_init: np.ndarray, y_init: np.ndarray, **kwargs) -> QuadratureLoopState:
     """Creates a BQ loop state object using the provided data.
 
     :param x_init: x values for initial function evaluations. Shape: (n_initial_points x n_input_dims)
@@ -45,4 +45,4 @@ def create_bq_loop_state(x_init: np.ndarray, y_init: np.ndarray, **kwargs) -> BQ
     """
 
     loop_state = create_loop_state(x_init, y_init, **kwargs)
-    return BQLoopState(loop_state.results)
+    return QuadratureLoopState(loop_state.results)

--- a/emukit/quadrature/loop/bq_outer_loop.py
+++ b/emukit/quadrature/loop/bq_outer_loop.py
@@ -1,0 +1,33 @@
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+from typing import List, Union
+from ...core.loop import OuterLoop
+
+from ...core.loop.candidate_point_calculators import CandidatePointCalculator
+from ...core.loop.model_updaters import ModelUpdater
+
+from .bq_loop_state import BQLoopState
+
+
+class BQOuterLoop(OuterLoop):
+    """Base class for a Bayesian quadrature outer loop.
+
+    :param candidate_point_calculator: Finds next point(s) to evaluate.
+    :param model_updater: Updates the model with the new data and fits the model hyper-parameters.
+    :param loop_state: Object that keeps track of the history of the BQ loop. Default is None, resulting in empty
+                       initial state.
+    """
+
+    def __init__(
+        self,
+        candidate_point_calculator: CandidatePointCalculator,
+        model_updater: Union[ModelUpdater, List[ModelUpdater]],
+        loop_state: BQLoopState = None,
+    ):
+        super().__init__(candidate_point_calculator, model_updater, loop_state)
+
+    def _update_loop_state_custom(self) -> None:
+        integral_mean, integral_var = self.model.integrate()
+        self.loop_state.update_integral_stats(integral_mean, integral_var)

--- a/emukit/quadrature/loop/bq_outer_loop.py
+++ b/emukit/quadrature/loop/bq_outer_loop.py
@@ -34,6 +34,6 @@ class QuadratureOuterLoop(OuterLoop):
         super().__init__(candidate_point_calculator, model_updaters, loop_state)
 
     def _update_loop_state(self) -> None:
-        model = self.model_updaters[0].model  # only works if there is a model, but for BQ nothing else makes sense
+        model = self.model_updaters[0].model  # only works if there is one model, but for BQ nothing else makes sense
         integral_mean, integral_var = model.integrate()
         self.loop_state.update_integral_stats(integral_mean, integral_var)

--- a/emukit/quadrature/loop/bq_outer_loop.py
+++ b/emukit/quadrature/loop/bq_outer_loop.py
@@ -7,11 +7,11 @@ from typing import List, Union
 from ...core.loop import OuterLoop
 from ...core.loop.candidate_point_calculators import CandidatePointCalculator
 from ...core.loop.model_updaters import ModelUpdater
-from .bq_loop_state import BQLoopState
+from .bq_loop_state import QuadratureLoopState
 
 
-class BQOuterLoop(OuterLoop):
-    """Base class for a Bayesian quadrature outer loop.
+class QuadratureOuterLoop(OuterLoop):
+    """Base class for a Bayesian quadrature loop.
 
     :param candidate_point_calculator: Finds next point(s) to evaluate.
     :param model_updaters: Updates the model with the new data and fits the model hyper-parameters.
@@ -26,7 +26,7 @@ class BQOuterLoop(OuterLoop):
         self,
         candidate_point_calculator: CandidatePointCalculator,
         model_updaters: Union[ModelUpdater, List[ModelUpdater]],
-        loop_state: BQLoopState = None,
+        loop_state: QuadratureLoopState = None,
     ):
         if isinstance(model_updaters, list):
             raise ValueError("The BQ loop only supports a single model.")

--- a/emukit/quadrature/loop/bq_stopping_conditions.py
+++ b/emukit/quadrature/loop/bq_stopping_conditions.py
@@ -7,8 +7,8 @@ import logging
 import numpy as np
 
 from ...core.loop.stopping_conditions import StoppingCondition
-
 from .bq_loop_state import BQLoopState
+
 _log = logging.getLogger(__name__)
 
 

--- a/emukit/quadrature/loop/bq_stopping_conditions.py
+++ b/emukit/quadrature/loop/bq_stopping_conditions.py
@@ -7,7 +7,7 @@ import logging
 import numpy as np
 
 from ...core.loop.stopping_conditions import StoppingCondition
-from .bq_loop_state import BQLoopState
+from .bq_loop_state import QuadratureLoopState
 
 _log = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class CoefficientOfVariationStoppingCondition(StoppingCondition):
     .. math::
         COV = \frac{\sigma}{\mu}
 
-    with :math:`\mu` and :math:`\sigma^2` the current mean and standard deviation of integral according to the
+    where :math:`\mu` and :math:`\sigma^2` are the current mean and standard deviation of integral according to the
     BQ posterior model.
 
     :param eps: Threshold under which the COV must fall.
@@ -37,7 +37,7 @@ class CoefficientOfVariationStoppingCondition(StoppingCondition):
         self.delay = delay
         self.times_true = 0  # counts how many times stopping had been triggered in a row
 
-    def should_stop(self, loop_state: BQLoopState) -> bool:
+    def should_stop(self, loop_state: QuadratureLoopState) -> bool:
         if len(loop_state.integral_means) < 1:
             return False
 

--- a/emukit/quadrature/loop/bq_stopping_conditions.py
+++ b/emukit/quadrature/loop/bq_stopping_conditions.py
@@ -20,11 +20,14 @@ class CoefficientOfVariationStoppingCondition(StoppingCondition):
     .. math::
         COV = \frac{\sigma}{\mu}
 
-    where :math:`\mu` and :math:`\sigma^2` are the current mean and standard deviation of integral according to the
-    BQ posterior model.
+    where :math:`\mu` and :math:`\sigma^2` are the current mean and variance respectively of the integral according to
+    the BQ posterior model.
 
     :param eps: Threshold under which the COV must fall.
     :param delay: Number of times the stopping condition needs to be true in a row in order to stop. Defaults to 1.
+
+    :raises ValueError: If `delay` is smaller than 1.
+    :raises ValueError: If `eps` is non-negative.
 
     """
 
@@ -33,9 +36,12 @@ class CoefficientOfVariationStoppingCondition(StoppingCondition):
         if delay < 1:
             raise ValueError(f"delay ({delay}) must be and integer greater than zero.")
 
+        if eps <= 0.0:
+            raise ValueError(f"eps ({eps}) must be positive.")
+
         self.eps = eps
         self.delay = delay
-        self.times_true = 0  # counts how many times stopping had been triggered in a row
+        self.times_true = 0  # counts how many times stopping has been triggered in a row
 
     def should_stop(self, loop_state: QuadratureLoopState) -> bool:
         if len(loop_state.integral_means) < 1:
@@ -50,11 +56,7 @@ class CoefficientOfVariationStoppingCondition(StoppingCondition):
         else:
             self.times_true = 0
 
-        print(np.sqrt(v) / m)
-        print(should_stop, self.times_true)
         should_stop = should_stop and (self.times_true >= self.delay)
-        print(should_stop)
-        print()
 
         if should_stop:
             _log.info(f"Stopped as coefficient of variation is below threshold of {self.eps}.")

--- a/emukit/quadrature/loop/bq_stopping_conditions.py
+++ b/emukit/quadrature/loop/bq_stopping_conditions.py
@@ -1,0 +1,61 @@
+# Copyright 2020-2024 The Emukit Authors. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import logging
+
+import numpy as np
+
+from ...core.loop.stopping_conditions import StoppingCondition
+
+from .bq_loop_state import BQLoopState
+_log = logging.getLogger(__name__)
+
+
+class CoefficientOfVariationStoppingCondition(StoppingCondition):
+    r"""Stops once the coefficient of variation (COV) falls below a threshold.
+
+    The COV is given by
+
+    .. math::
+        COV = \frac{\sigma}{\mu}
+
+    with :math:`\mu` and :math:`\sigma^2` the current mean and standard deviation of integral according to the
+    BQ posterior model.
+
+    :param eps: Threshold under which the COV must fall.
+    :param delay: Number of times the stopping condition needs to be true in a row in order to stop. Defaults to 1.
+
+    """
+
+    def __init__(self, eps: float, delay: int = 1) -> None:
+
+        if delay < 1:
+            raise ValueError(f"delay ({delay}) must be and integer greater than zero.")
+
+        self.eps = eps
+        self.delay = delay
+        self.times_true = 0  # counts how many times stopping had been triggered in a row
+
+    def should_stop(self, loop_state: BQLoopState) -> bool:
+        if len(loop_state.integral_means) < 1:
+            return False
+
+        m = loop_state.integral_means[-1]
+        v = loop_state.integral_vars[-1]
+        should_stop = (np.sqrt(v) / m) < self.eps
+
+        if should_stop:
+            self.times_true += 1
+        else:
+            self.times_true = 0
+
+        print(np.sqrt(v) / m)
+        print(should_stop, self.times_true)
+        should_stop = should_stop and (self.times_true >= self.delay)
+        print(should_stop)
+        print()
+
+        if should_stop:
+            _log.info(f"Stopped as coefficient of variation is below threshold of {self.eps}.")
+        return should_stop

--- a/emukit/quadrature/loop/vanilla_bq_loop.py
+++ b/emukit/quadrature/loop/vanilla_bq_loop.py
@@ -12,10 +12,10 @@ from ...core.parameter_space import ParameterSpace
 from ..acquisitions import IntegralVarianceReduction
 from ..methods import VanillaBayesianQuadrature
 from .bq_loop_state import create_bq_loop_state
-from .bq_outer_loop import BQOuterLoop
+from .bq_outer_loop import QuadratureOuterLoop
 
 
-class VanillaBayesianQuadratureLoop(BQOuterLoop):
+class VanillaBayesianQuadratureLoop(QuadratureOuterLoop):
     """The loop for standard ('vanilla') Bayesian Quadrature.
 
     .. seealso::

--- a/emukit/quadrature/loop/vanilla_bq_loop.py
+++ b/emukit/quadrature/loop/vanilla_bq_loop.py
@@ -6,15 +6,16 @@
 
 
 from ...core.acquisition import Acquisition
-from ...core.loop import FixedIntervalUpdater, ModelUpdater, OuterLoop, SequentialPointCalculator
-from ...core.loop.loop_state import create_loop_state
+from ...core.loop import FixedIntervalUpdater, ModelUpdater, SequentialPointCalculator
 from ...core.optimization import AcquisitionOptimizerBase, GradientAcquisitionOptimizer
 from ...core.parameter_space import ParameterSpace
 from ..acquisitions import IntegralVarianceReduction
 from ..methods import VanillaBayesianQuadrature
+from .bq_loop_state import create_bq_loop_state
+from .bq_outer_loop import BQOuterLoop
 
 
-class VanillaBayesianQuadratureLoop(OuterLoop):
+class VanillaBayesianQuadratureLoop(BQOuterLoop):
     """The loop for standard ('vanilla') Bayesian Quadrature.
 
     .. seealso::
@@ -46,7 +47,7 @@ class VanillaBayesianQuadratureLoop(OuterLoop):
         if acquisition_optimizer is None:
             acquisition_optimizer = GradientAcquisitionOptimizer(space)
         candidate_point_calculator = SequentialPointCalculator(acquisition, acquisition_optimizer)
-        loop_state = create_loop_state(model.X, model.Y)
+        loop_state = create_bq_loop_state(model.X, model.Y)
 
         super().__init__(candidate_point_calculator, model_updater, loop_state)
 

--- a/emukit/quadrature/loop/wsabil_loop.py
+++ b/emukit/quadrature/loop/wsabil_loop.py
@@ -5,15 +5,16 @@
 """The WSABI-L loop"""
 
 
-from ...core.loop import FixedIntervalUpdater, ModelUpdater, OuterLoop, SequentialPointCalculator
-from ...core.loop.loop_state import create_loop_state
+from ...core.loop import FixedIntervalUpdater, ModelUpdater, SequentialPointCalculator
 from ...core.optimization import AcquisitionOptimizerBase, GradientAcquisitionOptimizer
 from ...core.parameter_space import ParameterSpace
 from ..acquisitions import UncertaintySampling
 from ..methods import WSABIL
+from .bq_loop_state import create_bq_loop_state
+from .bq_outer_loop import BQOuterLoop
 
 
-class WSABILLoop(OuterLoop):
+class WSABILLoop(BQOuterLoop):
     """The loop for WSABI-L.
 
     .. rubric:: References
@@ -44,7 +45,7 @@ class WSABILLoop(OuterLoop):
         if acquisition_optimizer is None:
             acquisition_optimizer = GradientAcquisitionOptimizer(space)
         candidate_point_calculator = SequentialPointCalculator(acquisition, acquisition_optimizer)
-        loop_state = create_loop_state(model.X, model.Y)
+        loop_state = create_bq_loop_state(model.X, model.Y)
 
         super().__init__(candidate_point_calculator, model_updater, loop_state)
 

--- a/emukit/quadrature/loop/wsabil_loop.py
+++ b/emukit/quadrature/loop/wsabil_loop.py
@@ -11,10 +11,10 @@ from ...core.parameter_space import ParameterSpace
 from ..acquisitions import UncertaintySampling
 from ..methods import WSABIL
 from .bq_loop_state import create_bq_loop_state
-from .bq_outer_loop import BQOuterLoop
+from .bq_outer_loop import QuadratureOuterLoop
 
 
-class WSABILLoop(BQOuterLoop):
+class WSABILLoop(QuadratureOuterLoop):
     """The loop for WSABI-L.
 
     .. rubric:: References


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

@apaleyes This PR is a draft so far, but it would be great if you could have a look at the following points since it might require some changes in the core package, too.

The PR adds the COV stopping criterion for BQ. The stopping criterion needs access to the current integral mean and variance estimate. Stopping criteria currently only consume the `LoopState` to decide when to stop. The mentioned statistics are currently not stored in `LoopState` (only X and Y are). 

So, how can stopping criteria access model statistics to assess stopping?

1. One way is to change the `LoopState` class in the core package. For example the `loop_state.update` method could also request the models in addition to X and Y. But this is a bit tricky since:
   - the models are not directly accessible in the `OuterLoop` where `loop_state.update()` is called (only the model updaters are accessible which, in their basic form, do not even necessarily contain a model).
   - The relevant model stats need to be added to the loop state after the models are updated and not after the new points are collected (where `update` is currently called).
   - So one way would be to add a method `update_model_stats` to the core `LoopState` class which is called in the loop after the  updated, similar to how `loop_state.update` is called. This method could do nothing initially but could be overridden by specific packages. It is unclear however, what the inputs to this method are supposed to be (the model updaters without models??) and potentially the model updaters need to be adjusted to contain models.

Here is another approach (which reflects the code in this PR)

2. The core `OuterLoop` already contains a method `_update_models`. I added another method called `_update_loop_state` which does nothing in the base class, but can be overridden by other loop states. In comparison to the first approach, this one not only requires a new method in `LoopState` but also in `OuterLoop` that both need to be overridden in specific packages if needed. So it is less principled since a method in `OuterLoop` somehow meddles with how the loop state is being updated. But therefore there are no additional assumptions on the core model updaters.

I personally think that the first approach is neater but would require more changes in the core package. The second approach feels a bit hacky but most of the changes happen in the quadrature package instead of the core package. 

Before I implement tests etc, let me know please what you think about both options or if you have another idea on how to incorporate stopping criteria that are based on model statistics (in BQ there are several, I just added the COV criterion as an example).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
