### PR TITLE
Install mpl differently, bring windows back

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,8 +3,9 @@ setuptools>=40.8.0
 # until GPy is updated we need to avoid 1.24 or higher
 numpy>=1.23
 # This is unfortunate - we don't need matplotlib
-# but until GPy and GPyOpt get their dependencies straight
-# we need GPy's plotting extra to ensure smooth installation
-GPy[plotting]>=1.13.0
+# but until GPy gets its dependencies straight
+# we need matplotlib to ensure smooth installation
+matplotlib>=3.9
+GPy>=1.13.0
 emcee>=2.2.1
 scipy>=1.1.0


### PR DESCRIPTION
*Issue #, if available:* #461

*Description of changes:* Instead of relying on GPy that hardcodes matplotlib version (which seems broken, see issue), let's install matplotlib separately. GPy, unfortunately, still requires matplotlib implicitly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
