### PR TITLE
feat: fixes benchmark plot legend, adds logy option

### DIFF
--- a/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
@@ -77,7 +77,7 @@ class BenchmarkPlot:
     def make_plot(self, log_y: bool = False) -> None:
         """
         Make one plot for each metric measured, comparing the different loop results against each other
-        
+
         :param log_y: Set the y axis to log scaling if true.
         """
 
@@ -120,15 +120,15 @@ class BenchmarkPlot:
                 plt.xlabel(self.x_label)
                 fill_plt = plt.fill_between(x, mean - std, mean + std, alpha=0.2, color=colour)
                 legend_handles.append((fill_plt, mean_plt[0]))
-              
+
             # Make legend
             plt.legend(legend_handles, self.loop_names)
             plt.tight_layout()
 
             plt.xlim(min_x, max_x)
-            
-            if log_y: 
-                plt.yscale('log')
+
+            if log_y:
+                plt.yscale("log")
 
     def save_plot(self, file_name: str) -> None:
         """

--- a/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
@@ -74,9 +74,11 @@ class BenchmarkPlot:
         self.fig_handle = None
         self.x_axis = x_axis_metric_name
 
-    def make_plot(self, logy: bool = False) -> None:
+    def make_plot(self, log_y: bool = False) -> None:
         """
         Make one plot for each metric measured, comparing the different loop results against each other
+        
+        :param log_y: Set the y axis to log scaling if true.
         """
 
         n_metrics = len(self.metrics_to_plot)
@@ -125,7 +127,7 @@ class BenchmarkPlot:
 
             plt.xlim(min_x, max_x)
             
-            if logy: 
+            if log_y: 
                 plt.yscale('log')
 
     def save_plot(self, file_name: str) -> None:

--- a/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
+++ b/emukit/benchmarking/loop_benchmarking/benchmark_plot.py
@@ -74,7 +74,7 @@ class BenchmarkPlot:
         self.fig_handle = None
         self.x_axis = x_axis_metric_name
 
-    def make_plot(self) -> None:
+    def make_plot(self, logy: bool = False) -> None:
         """
         Make one plot for each metric measured, comparing the different loop results against each other
         """
@@ -92,6 +92,7 @@ class BenchmarkPlot:
             min_x = np.inf
             max_x = -np.inf
 
+            legend_handles = []
             for j, loop_name in enumerate(self.loop_names):
                 # Get all results for this metric
                 metric = self.benchmark_results.extract_metric_as_array(loop_name, metric_name)
@@ -113,15 +114,19 @@ class BenchmarkPlot:
                 max_x = np.max([np.max(x), max_x])
 
                 # Plot
-                plt.plot(x, mean, color=colour, linestyle=line_style)
+                mean_plt = plt.plot(x, mean, color=colour, linestyle=line_style)
                 plt.xlabel(self.x_label)
-                plt.fill_between(x, mean - std, mean + std, alpha=0.2, color=colour)
-
+                fill_plt = plt.fill_between(x, mean - std, mean + std, alpha=0.2, color=colour)
+                legend_handles.append((fill_plt, mean_plt[0]))
+              
             # Make legend
-            plt.legend(self.loop_names)
+            plt.legend(legend_handles, self.loop_names)
             plt.tight_layout()
 
             plt.xlim(min_x, max_x)
+            
+            if logy: 
+                plt.yscale('log')
 
     def save_plot(self, file_name: str) -> None:
         """


### PR DESCRIPTION
The BenchmarkPlot does not correctly label the experiment loops colors or line styles in the legend
(Using Python 3.12.0 and matplotlib 3.10.0 and emukit 0.4.11). See issue here: https://github.com/EmuKit/emukit/issues/472#issuecomment-2644781883

I fixed the issue with just a few lines of code by setting up legend handles manually. In addition I added the option to set the y_axis to log scale which is the standard in literature for plotting regret.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
